### PR TITLE
Add MSI App Player registry support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![GUI Screenshot](https://github.com/user-attachments/assets/10f965eb-e1cc-4d61-9b6f-0cbb484a4ef0)
 
-BlueStacks Root GUI is a utility designed to easily toggle root access settings and enable read/write (R/W) permissions for your BlueStacks 5 instances (specifically targeting BlueStacks_nxt structure). It aims to simplify the process described in the original guide: **[Root BlueStacks with Kitsune Mask](https://github.com/RobThePCGuy/Root-Bluestacks-with-Kitsune-Mask/)** by providing a graphical interface.
+BlueStacks Root GUI is a utility designed to easily toggle root access settings and enable read/write (R/W) permissions for your BlueStacks 5 instances (specifically targeting the `BlueStacks_nxt` structure and the MSI App Player's `BlueStacks_msi5`). It aims to simplify the process described in the original guide: **[Root BlueStacks with Kitsune Mask](https://github.com/RobThePCGuy/Root-Bluestacks-with-Kitsune-Mask/)** by providing a graphical interface.
 
 ---
 
@@ -26,7 +26,7 @@ BlueStacks Root GUI is a utility designed to easily toggle root access settings 
 
 ## Features
 
-- **Auto-Detection:** Discovers BlueStacks installation paths via the Windows Registry (`SOFTWARE\BlueStacks_nxt`).
+- **Auto-Detection:** Discovers BlueStacks installation paths via the Windows Registry (`SOFTWARE\BlueStacks_nxt` or `SOFTWARE\BlueStacks_msi5`).
 - **Instance Listing:** Reads `bluestacks.conf` to find and list configured instances.
 - **Root Toggle:** Modifies `bst.instance.<name>.enable_root_access` and `bst.feature.rooting` in `bluestacks.conf`.
 - **Read/Write Toggle:** Modifies the `Type` attribute (`Normal` vs `Readonly`) for key disk files (`fastboot.vdi`, `Root.vhd`) within instance-specific `.bstk` files.
@@ -38,7 +38,7 @@ BlueStacks Root GUI is a utility designed to easily toggle root access settings 
 ## Prerequisites
 
 - **Operating System:** Windows 10 or later (due to registry keys and file paths used).
-- **BlueStacks Version:** BlueStacks 5 (specifically versions using the `BlueStacks_nxt` registry key and configuration structure). *Compatibility with other versions is not guaranteed.*
+- **BlueStacks Version:** BlueStacks 5 or MSI App Player (versions using the `BlueStacks_nxt` or `BlueStacks_msi5` registry keys and configuration structure). *Compatibility with other versions is not guaranteed.*
 - **Python (for development):** Python 3.7+
 - **Administrator Rights:** **Required** to read the HKLM registry and terminate BlueStacks processes effectively. Run the application as an administrator.
 - **Dependencies:** Listed in `requirements.txt`. Key dependencies include `PyQt5`, `pywin32`, `psutil`.
@@ -115,7 +115,7 @@ BlueStacks Root GUI is a utility designed to easily toggle root access settings 
 
 -   **"Path Not Found" / No Instances Listed:**
     *   Ensure you ran the GUI as **administrator**.
-    *   Verify BlueStacks 5 is installed correctly and the registry keys (`HKLM\SOFTWARE\BlueStacks_nxt\UserDefinedDir` and `DataDir`) exist.
+     *   Verify BlueStacks 5 or MSI App Player is installed correctly and the registry keys (`HKLM\SOFTWARE\BlueStacks_nxt\UserDefinedDir` and `DataDir` or `HKLM\SOFTWARE\BlueStacks_msi5`) exist.
     *   A clean reinstall of BlueStacks using the official cleaner tool might be necessary.
 -   **Permission Errors during Toggle:**
     *   You *must* run the GUI as administrator.

--- a/constants.py
+++ b/constants.py
@@ -8,6 +8,7 @@ BLUESTACKS_CONF_FILENAME = "bluestacks.conf"
 
 
 REGISTRY_BASE_PATH = r"SOFTWARE\BlueStacks_nxt"
+REGISTRY_MSI_BASE_PATH = r"SOFTWARE\BlueStacks_msi5"
 REGISTRY_DATA_DIR_KEY = "DataDir"
 REGISTRY_USER_DIR_KEY = "UserDefinedDir"
 

--- a/registry_handler.py
+++ b/registry_handler.py
@@ -13,75 +13,73 @@ def get_bluestacks_path(
     key_name: str = constants.REGISTRY_DATA_DIR_KEY,
 ) -> Optional[str]:
     """
-    Retrieves a specific registry string value from the BlueStacks registry key.
+    Retrieves a specific registry string value from the BlueStacks or MSI App
+    Player registry keys.
 
-    Looks under HKEY_LOCAL_MACHINE\\SOFTWARE\\BlueStacks_nxt.
+    Checks ``HKEY_LOCAL_MACHINE\SOFTWARE\BlueStacks_nxt`` first and then
+    ``HKEY_LOCAL_MACHINE\SOFTWARE\BlueStacks_msi5`` if not found.
 
     Args:
-        key_name: The registry value name to retrieve (e.g., "DataDir", "UserDefinedDir").
-                  Defaults to constants.REGISTRY_DATA_DIR_KEY.
+        key_name: The registry value name to retrieve (e.g., "DataDir",
+            "UserDefinedDir"). Defaults to ``constants.REGISTRY_DATA_DIR_KEY``.
 
     Returns:
-        The string value of the registry key if found and is of type REG_SZ.
-        None if the path/key is not found, access is denied, the key is not
-        a string, or any other error occurs.
+        The string value of the registry key if found and of type ``REG_SZ``.
+        ``None`` if the key or value is missing, access is denied, the value is
+        not a string, or any other error occurs.
     """
 
-    reg_path = constants.REGISTRY_BASE_PATH
-    full_reg_path_log = f"HKEY_LOCAL_MACHINE\\{reg_path}"
     value: Optional[str] = None
-
-    try:
-        logger.debug(f"Attempting to open registry key: {full_reg_path_log}")
-
-        with winreg.OpenKey(
-            winreg.HKEY_LOCAL_MACHINE, reg_path, 0, winreg.KEY_READ
-        ) as key:
-            logger.debug(
-                f"Successfully opened registry key. Querying value for '{key_name}'."
-            )
-
-            reg_value, reg_type = winreg.QueryValueEx(key, key_name)
-
-            if reg_type == winreg.REG_SZ:
-                value = str(reg_value)
-                logger.info(f"Found registry key '{key_name}' with value: {value}")
-            else:
-                logger.warning(
-                    f"Registry key '{key_name}' found but is not a string (Type: {reg_type}). Value: {reg_value}"
+    for reg_path in (constants.REGISTRY_BASE_PATH, constants.REGISTRY_MSI_BASE_PATH):
+        full_reg_path_log = f"HKEY_LOCAL_MACHINE\\{reg_path}"
+        try:
+            logger.debug(f"Attempting to open registry key: {full_reg_path_log}")
+            with winreg.OpenKey(
+                winreg.HKEY_LOCAL_MACHINE, reg_path, 0, winreg.KEY_READ
+            ) as key:
+                logger.debug(
+                    f"Successfully opened registry key. Querying value for '{key_name}'."
                 )
-                value = None
-
-    except FileNotFoundError:
-        logger.warning(
-            f"Registry path {full_reg_path_log} or value name '{key_name}' not found."
-        )
-        value = None
-    except PermissionError:
-
-        logger.error(
-            f"Permission denied accessing registry value '{key_name}' at {full_reg_path_log}. Try running as administrator."
-        )
-        value = None
-    except OSError as e:
-
-        if e.winerror == 5:
+                reg_value, reg_type = winreg.QueryValueEx(key, key_name)
+                if reg_type == winreg.REG_SZ:
+                    value = str(reg_value)
+                    logger.info(
+                        f"Found registry key '{key_name}' with value: {value}"
+                    )
+                    return value
+                else:
+                    logger.warning(
+                        f"Registry key '{key_name}' found but is not a string (Type: {reg_type}). Value: {reg_value}"
+                    )
+        except FileNotFoundError:
+            logger.debug(
+                f"Registry path {full_reg_path_log} or value '{key_name}' not found."
+            )
+            continue
+        except PermissionError:
             logger.error(
-                f"Permission denied accessing registry value '{key_name}' at {full_reg_path_log} (OSError: {e}). Try running as administrator."
+                f"Permission denied accessing registry value '{key_name}' at {full_reg_path_log}. Try running as administrator."
             )
-        elif e.winerror == 2:
-            logger.warning(
-                f"Registry path {full_reg_path_log} or value name '{key_name}' not found (OSError: {e})."
+            return None
+        except OSError as e:
+            if e.winerror == 5:
+                logger.error(
+                    f"Permission denied accessing registry value '{key_name}' at {full_reg_path_log} (OSError: {e}). Try running as administrator."
+                )
+            elif e.winerror == 2:
+                logger.debug(
+                    f"Registry path {full_reg_path_log} or value name '{key_name}' not found (OSError: {e})."
+                )
+                continue
+            else:
+                logger.error(
+                    f"OS error accessing registry value '{key_name}' at {full_reg_path_log}: {e}"
+                )
+            return None
+        except Exception as e:
+            logger.exception(
+                f"An unexpected error occurred accessing registry value '{key_name}' at {full_reg_path_log}: {e}"
             )
-        else:
-            logger.error(
-                f"OS error accessing registry value '{key_name}' at {full_reg_path_log}: {e}"
-            )
-        value = None
-    except Exception as e:
-        logger.exception(
-            f"An unexpected error occurred accessing registry value '{key_name}' at {full_reg_path_log}: {e}"
-        )
-        value = None
+            return None
 
     return value


### PR DESCRIPTION
## Summary
- add detection of MSI App Player registry key
- update registry access logic to search both `BlueStacks_nxt` and `BlueStacks_msi5`
- document MSI App Player support in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685031ea39d0832487cc222faaf13db8