### PR TITLE
Add CI workflow (lint + compile check)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install ruff
+        run: pip install ruff
+
+      # Lint: flake8 "must-fix" set (real syntax errors, undefined names,
+      # invalid literal comparisons) plus unused-import detection. Kept lean
+      # so the gate is green and meaningful without forcing a full reformat.
+      # pywin32 is Windows-only; ruff does not import the code, so this is
+      # safe to run on the Linux runner.
+      - name: Ruff lint
+        run: ruff check --select E9,F63,F7,F82,F401 .
+
+      # Compile check: catches syntax errors across every module. compileall
+      # compiles without importing, so the Windows-only pywin32 import in
+      # registry_handler.py does not break this on ubuntu.
+      - name: Compile check
+        run: python -m compileall -q .

--- a/config_handler.py
+++ b/config_handler.py
@@ -2,7 +2,7 @@
 import os
 import logging
 import re
-from typing import Dict, Any, Optional
+from typing import Dict, Any
 
 
 import constants

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@
 import sys
 import os
 import logging
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, List
 
 from PyQt5.QtWidgets import (
     QApplication,
@@ -14,13 +14,9 @@ from PyQt5.QtWidgets import (
     QGridLayout,
     QGroupBox,
     QCheckBox,
-    QComboBox,
     QMessageBox,
-    QProgressBar,
-    QSizePolicy,
-    QSpacerItem,
 )
-from PyQt5.QtCore import Qt, QTimer, QThread, pyqtSignal, QObject, pyqtSlot
+from PyQt5.QtCore import Qt, QTimer, QThread
 from PyQt5.QtGui import QIcon
 
 

--- a/registry_handler.py
+++ b/registry_handler.py
@@ -1,7 +1,7 @@
 import winreg
 import logging
 import os
-from typing import Optional, List, Dict, Any
+from typing import List, Dict, Any
 
 import constants
 


### PR DESCRIPTION
## What

Adds `.github/workflows/ci.yml` — the repo previously had no CI (only dependabot auto-merge).

A single **`verify`** job (`ubuntu-latest`, `timeout-minutes: 15`) on Python 3.12 runs:

- **Ruff lint** — `ruff check --select E9,F63,F7,F82,F401 .` — the flake8 "must-fix" set (real syntax errors, undefined names, invalid literal comparisons) plus unused-import detection. Lean and green; does not force a full reformat.
- **Compile check** — `python -m compileall -q .` — catches syntax errors across all modules. Compiles without importing, so the Windows-only `pywin32`/`winreg` imports do not break it on Linux.

Triggers: `pull_request`, `push` to `master`, and `workflow_dispatch`. `permissions: contents: read`.

## Pre-existing lint fixed

To make the gate green, removed unused imports (F401) only — no logic changes:

- `typing.Optional` in `config_handler.py`, `main.py`, `registry_handler.py`
- Unused PyQt5 symbols in `main.py`: `QComboBox`, `QProgressBar`, `QSizePolicy`, `QSpacerItem`, `pyqtSignal`, `QObject`, `pyqtSlot`

## Notes

- No tests exist in the repo; the app requires Windows + `pywin32`, so tests are intentionally not run in CI.
- Style issues like multiple-statements-per-line (E701/E702) are intentionally **not** gated to avoid churning existing code.

https://claude.ai/code/session_01Vg98HKtwzX7wLWsNhS3Pyi