### PR TITLE
Harden #27: auto-kill Manager, restore brick-guard, binary audit

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -61,6 +61,10 @@ REGEX_BSTK_READONLY_PATTERN = re.compile(
 
 BLUESTACKS_PROCESS_NAMES = [
     "HD-Player.exe",
+    # Must be terminated before patching: the engine patch rewrites
+    # HD-MultiInstanceManager.exe, and Windows denies the write while the
+    # Manager window is open (its .exe is locked).
+    "HD-MultiInstanceManager.exe",
     "BlueStacks.exe",
     "HD-Agent.exe",
     "BstkSVC.exe",

--- a/integrity_patch.py
+++ b/integrity_patch.py
@@ -40,6 +40,7 @@ Usage (standalone)::
 from __future__ import annotations
 
 import argparse
+import hashlib
 import logging
 import os
 import shutil
@@ -277,16 +278,62 @@ def patch_file(path: str, specs: List[PatchSpec] = (DISK_INTEGRITY_CALL,),
             logger.info("Backed up original to %s", backup)
     with open(path, "wb") as fh:
         fh.write(data)
+    # Record the hash of the file *as we just patched it*. restore_file() uses
+    # this to detect the case where BlueStacks auto-updated the binary to a new
+    # version after we patched: restoring the stale backup over a newer binary
+    # would mismatch the rest of the install and could break the player.
+    if make_backup:
+        try:
+            with open(backup + ".sha256", "w", encoding="utf-8") as fh:
+                fh.write(_sha256(path))
+        except OSError:
+            logger.debug("Could not record patched-file hash for %s", path, exc_info=True)
     return True
 
 
+def _sha256(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
 def restore_file(path: str) -> bool:
-    """Restore a binary from its ``.prepatch.bak`` backup. Returns True if done."""
+    """Restore a binary from its ``.prepatch.bak`` backup. Returns True if done.
+
+    Refuses to restore when the current on-disk binary is not the one we patched
+    (its hash no longer matches what patch_file() recorded) -- that means
+    BlueStacks replaced it with a newer build, and overwriting it with our stale
+    backup could leave the install inconsistent. In that case the fresh binary is
+    already unpatched, so there is nothing to restore anyway.
+    """
     backup = path + BACKUP_SUFFIX
     if not os.path.exists(backup):
         logger.warning("No backup found for %s", path)
         return False
+    meta = backup + ".sha256"
+    if os.path.exists(meta) and os.path.exists(path):
+        try:
+            recorded = open(meta, encoding="utf-8").read().strip()
+        except OSError:
+            recorded = ""
+        if recorded:
+            current = _sha256(path)
+            if current != recorded:
+                logger.warning(
+                    "%s changed since it was patched (current %s != patched %s) -- "
+                    "BlueStacks likely updated it. Refusing to overwrite the newer "
+                    "binary with the stale backup.",
+                    os.path.basename(path), current[:12], recorded[:12])
+                return False
     shutil.copy2(backup, path)
+    for stale in (meta,):  # patched-hash record is meaningless once restored
+        try:
+            if os.path.exists(stale):
+                os.remove(stale)
+        except OSError:
+            pass
     logger.info("Restored %s from backup", path)
     return True
 

--- a/tools/e2fsprogs/README.md
+++ b/tools/e2fsprogs/README.md
@@ -53,3 +53,32 @@ The PyInstaller build ships this folder inside the executable:
 
 At runtime `ext4_symlink._tool_dir()` resolves it from `sys._MEIPASS` (frozen) or
 this directory (running from source).
+
+## Verification (audited 2026-07-07)
+
+The bundled binaries were audited before inclusion:
+
+- **PE import tables** contain no networking, crypto, or process-injection APIs.
+  `debugfs.exe` / `e2fsck.exe` link only the sibling `cyg*` DLLs, `cygwin1.dll`,
+  and `KERNEL32`; `cygwin1.dll` imports only `KERNEL32` + `ntdll` (the normal
+  Cygwin runtime shape). A tool that phoned home or injected would need APIs
+  that are simply absent here.
+- **Version self-report** in `debugfs.exe` / `e2fsck.exe` is `1.44.5`
+  (build date `15-Dec-2018`), matching the e2fsprogs 1.44.5 claim above.
+
+SHA-256 of each shipped file (verify after any change to this folder):
+
+```
+cb2228400b88b60e685d7ca8815b7f3d7773aeb53f2943586545b66568dd745a debugfs.exe
+aadfcfbb1f69e2e4af9980c566f718d34177acb4529a6ae29af4f2f01984f378 e2fsck.exe
+c648a92c3881e904abaff5369917bb8dd0cecfafc5cccd93c0fc30e670e311d3 cygblkid-1.dll
+8d7451ebc8bd8601d9116c4873d4a8b0ea5fc2d9c2330716180efeeb2ae7045b cygcom_err-2.dll
+b6fc78c540f69f3c47cbfedcea34c608bb6217dca9684e0ea274eb486f1f8ace cyge2p-2.dll
+9d7ba40ac9eee500f6590eb68a9d9a19e7a5a57a6df0e625432d22838968b1ae cygext2fs-2.dll
+bbb18620491599a93676a96c67ab986c3e5a592ba1bbdfb43abf2f26ab09c1ba cyggcc_s-seh-1.dll
+20c86120799424c45a981ffa4b3bfe8a99204845633b6c3c6dda06770fdbb7e8 cygiconv-2.dll
+4e8159a9eba4ccd4c73864e74d0ad6811598e84ad7e23c27a3cf0dc9da5e183e cygintl-8.dll
+29728a0cfbb09e850547b6787b0b6881a9273483548f0a400981ad2226bb74ed cygss-2.dll
+53cf0bd45e4a3e8cde1ca30b0a0797055286a56ad9c271d4903b971da7354fcb cyguuid-1.dll
+d5562774ec1475bd1dab84c5249b273e60cc53e6aa968981414a4d6a3f8e2bfd cygwin1.dll
+```


### PR DESCRIPTION
Follow-up to #27, from a live root test on **5.22.232.1002 / Android 13** (engine patched, both guest `su` patched in Data.vhdx, booted with no tamper shutdown, Root Checker confirmed root).

Three hardening changes:

- **Auto-kill the Manager before patching** (`constants.py`) — the engine patch rewrites `HD-MultiInstanceManager.exe`, but that process wasn't in the terminate list, so the write failed with `Permission denied` whenever the Manager window was open. Adding it to `BLUESTACKS_PROCESS_NAMES` makes `terminate_bluestacks()` close it first. Confirmed fixed live (tool now terminates the PID before patching).
- **Restore brick-guard** (`integrity_patch.py`) — `restore_file()` now records the patched file's SHA-256 and refuses to overwrite a binary BlueStacks has since updated with the stale `.prepatch.bak`, avoiding a version-mismatch break. Old backups without a hash record still restore. Unit-tested (normal restore, stale-backup refusal, legacy fallback).
- **Binary provenance audit** (`tools/e2fsprogs/README.md`) — documents the pre-inclusion audit (clean PE import tables — no networking/crypto/injection; self-reported e2fsprogs 1.44.5 / Dec-2018) plus a SHA-256 manifest of all 12 shipped binaries.