### PR TITLE
docs: refresh README for latest-version root support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,29 @@
 
 [![GitHub Repo Stars](https://img.shields.io/github/stars/RobThePCGuy/BlueStacks-Root-GUI?style=social)](https://github.com/RobThePCGuy/BlueStacks-Root-GUI)
 [![YouTube Video Views](https://img.shields.io/youtube/views/zpihBs3FtEc?style=social)](https://youtu.be/zpihBs3FtEc)
-[![Last Updated](https://img.shields.io/github/last-commit/RobThePCGuy/BlueStacks-Root-GUI)](https://github.com/RobThePCGuy/BlueStacks-Root-GUI/commits/main)
+[![Last Updated](https://img.shields.io/github/last-commit/RobThePCGuy/BlueStacks-Root-GUI)](https://github.com/RobThePCGuy/BlueStacks-Root-GUI/commits/master)
 
 ---
 
 ![GUI Screenshot](https://github.com/user-attachments/assets/10f965eb-e1cc-4d61-9b6f-0cbb484a4ef0)
 
-A utility designed to easily toggle root access and enable read/write (R/W) permissions for BlueStacks 5 instances. Provides a graphical interface for the process described in **[Root BlueStacks with Kitsune Mask](https://github.com/RobThePCGuy/Root-Bluestacks-with-Kitsune-Mask/)**.
+A utility to toggle root access and read/write (R/W) permissions for BlueStacks 5 instances from a simple graphical interface. It automates the process described in **[Root BlueStacks with Kitsune Mask](https://github.com/RobThePCGuy/Root-Bluestacks-with-Kitsune-Mask/)**.
 
-> [!WARNING]
-> **BlueStacks 5.22+ users:** See [Version Compatibility](#version-compatibility) for known issues with recent updates.
+> [!TIP]
+> **The latest BlueStacks now roots — no downgrade required.** BlueStacks 5.22 added a disk-integrity check that shut rooted instances down with *"Android system doesn't meet security requirements"*. This tool patches that check out, so you can root the current build instead of hunting for an old one. Confirmed working on **5.22.232.1002 / Android 13** (see [Version Compatibility](#version-compatibility)). If you were told to downgrade to 5.21, you no longer have to.
 
 ---
 
 ## Table of Contents
 
 - [Features](#features)
+- [How It Works](#how-it-works)
 - [Prerequisites](#prerequisites)
 - [Installation](#installation)
 - [Usage Guide](#usage-guide)
+  - [Patch-Mode Builds (5.22.150.1014+)](#patch-mode-builds-52215010141)
+  - [Classic Builds (5.22.130 and older / MSI)](#classic-builds-522130-and-older--msi)
+  - [Keep Root After Updates](#keep-root-after-updates)
 - [Troubleshooting](#troubleshooting)
 - [Development](#development)
 - [Contributing](#contributing)
@@ -29,20 +33,34 @@ A utility designed to easily toggle root access and enable read/write (R/W) perm
 
 ## Features
 
-- **Auto-Detection** - Discovers BlueStacks installation paths via Windows Registry (Normal, China, and MSI editions)
-- **Instance Listing** - Reads `bluestacks.conf` to display all configured instances
-- **Root Toggle** - Modifies `bst.instance.<name>.enable_root_access` and `bst.feature.rooting`
-- **Read/Write Toggle** - Changes disk file attributes (`fastboot.vdi`, `Root.vhd`) between `Normal` and `Readonly`
-- **Process Handling** - Detects and gracefully terminates BlueStacks processes before applying changes
-- **Status Display** - Shows current Root and R/W status for each instance
-- **Responsive UI** - Uses background threads (`QThread`) to keep the interface responsive
+- **Auto-Detection** - Discovers BlueStacks installation paths via the Windows Registry (Normal, China, and MSI editions) and picks the right rooting method per version automatically
+- **Instance Listing** - Reads `bluestacks.conf` to display all configured instances with live Root and R/W status
+- **Root Toggle** - Enables root the right way for your build: the `enable_root_access` / `bst.feature.rooting` flags on classic builds, plus an offline guest-`su` patch on 5.22.150.1014+
+- **Engine Patch (5.22+)** - Patches `HD-Player.exe` to disable the *"doesn't meet security"* integrity shutdown, and `HD-MultiInstanceManager.exe` so root isn't reset back off when you edit instances
+- **Read/Write Toggle** - Switches disk files (`fastboot.vdi`, `Root.vhd`) between `Normal` and `Readonly`
+- **Reversible** - Every binary patch backs up to a `.prepatch.bak`; every guest-`su` patch records the original bytes. "Undo Engine Patch" and toggling root off restore the originals
+- **Process Handling** - Closes all BlueStacks processes (player, services, and the Multi-Instance Manager) before applying changes
+- **Responsive UI** - Long operations run on background threads (`QThread`) so the window never freezes
 - **Internationalization** - Includes English and Japanese translations
+
+## How It Works
+
+BlueStacks changed how it locks down root across versions, so the tool uses two approaches and chooses automatically based on the detected version.
+
+**Classic builds (5.22.130 and older, and MSI):** root is the original flag-based method. Setting `bst.instance.<name>.enable_root_access=1` exposes the guest `su`. On some builds `su` only lives at `/system/xbin/bstk/su` (not on the app `PATH`), so root-checker *apps* report "not rooted" even though a shell gets `uid=0`; the tool adds a `/system/xbin/su` symlink offline so apps see it too.
+
+**Patch-mode builds (5.22.150.1014+):** BlueStacks added two locks. First, `HD-Player.exe` runs a disk-integrity check on boot and force-closes a modified instance with the *"illegally tampered"* popup. Second, the guest `su` was rewritten to grant root only to a signed whitelist. The tool defeats both:
+
+1. **Engine patch** - flips `_isDiskVerificationRequired()` in `HD-Player.exe` to return 0, which disables the integrity shutdown **and** turns on Developer Mode. It also NOPs the routine in `HD-MultiInstanceManager.exe` that resets `enable_root_access` to 0.
+2. **Guest-`su` patch** - opens the instance's `Data.vhdx` directly (no running instance, no ADB), finds every guest `su`, and flips its `isDeveloperMode()` gate to always-grant so root works for **every app**.
+
+Both patches are located by byte signature, not hard-coded offsets, so they survive minor version rebuilds, and both are fully reversible.
 
 ## Prerequisites
 
 - **Operating System:** Windows 10 or later
-- **BlueStacks Version:** BlueStacks 5 or MSI App Player (5.21 or earlier recommended)
-- **Administrator Rights:** Required for registry access and process termination
+- **BlueStacks Version:** BlueStacks 5 or MSI App Player — **any current version works**, including the latest 5.22.x (see [Version Compatibility](#version-compatibility))
+- **Administrator Rights:** Required for registry access, patching files under `Program Files`, and terminating BlueStacks processes
 - **Python (development only):** Python 3.7+
 
 ## Installation
@@ -52,9 +70,8 @@ A utility designed to easily toggle root access and enable read/write (R/W) perm
 1. Download the latest `.exe` from **[Releases](https://github.com/RobThePCGuy/BlueStacks-Root-GUI/releases)**
 2. Right-click the executable and select **"Run as administrator"**
 
-**Before first use:**
-- Uninstall previous BlueStacks versions using the official **[BlueStacks Cleaner tool](https://support.bluestacks.com/hc/en-us/articles/360057724751-How-to-uninstall-BlueStacks-5-BlueStacks-X-and-BlueStacks-Services-completely-from-your-PC)**
-- Install **BlueStacks 5.21 or earlier** (see [Version Compatibility](#version-compatibility))
+> [!NOTE]
+> You do **not** need to uninstall or downgrade BlueStacks first. Install or keep whatever current version you like — the tool patches it in place. (Downgrade instructions are still kept [below](#how-to-downgrade-to-521-legacy) for anyone who wants the old approach.)
 
 ### Option 2: Run from Source
 
@@ -80,13 +97,23 @@ Output will be in the `dist/` folder.
 
 ## Usage Guide
 
-### Initial Setup
+Launch the GUI **as administrator**. It auto-detects your BlueStacks installation, lists your instances, and shows the engine-patch buttons only when a patch-mode build (5.22.150.1014+) is present. Follow the section that matches your version.
 
-1. Launch the GUI **as administrator**
-2. The app will auto-detect your BlueStacks installation and list available instances
-3. Select the instance(s) you want to modify
+### Patch-Mode Builds (5.22.150.1014+)
 
-### Installing Kitsune Mask
+This is the path for current BlueStacks. You get root for apps without touching `/system` or installing anything in the guest.
+
+1. **Create the instance first** - if it's a brand-new install, open BlueStacks once so it builds and boots your instance, then close it. The guest `su` only appears in `Data.vhdx` after the first boot.
+2. **Patch the engine (once per install)** - click **"Patch BlueStacks Engine (required for root)"** → **Yes**. All BlueStacks processes are closed first, then `HD-Player.exe` and `HD-MultiInstanceManager.exe` are patched and backed up.
+3. **Toggle root (per instance)** - tick the instance and click **"Toggle Root."** This sets the root flags and patches the guest `su` inside `Data.vhdx`. If it reports that `su` isn't there yet, boot the instance once and toggle again.
+4. **Restart the instance** - start it from BlueStacks. It should boot with **no** security/tamper popup, and root-checker apps (or Kitsune Mask / Magisk) will see root.
+
+> [!TIP]
+> Want Kitsune Mask / Magisk modules too? You can still install them — enable **R/W**, install the APK, and follow the [Kitsune steps](#classic-builds-522130-and-older--msi) below. It's optional on patch-mode builds since apps already have root.
+
+### Classic Builds (5.22.130 and older / MSI)
+
+The original flag-based flow, used to install Kitsune Mask into `/system`.
 
 1. **Enable Root & R/W**
    - Select your target instance
@@ -97,10 +124,10 @@ Output will be in the `dist/` folder.
    - Download **[Kitsune Mask APK](https://github.com/1q23lyc45/KitsuneMagisk/releases)**
    - Launch the instance via BlueStacks Multi-Instance Manager
    - Install the APK (drag-and-drop)
-   - Open Kitsune Mask app
+   - Open the Kitsune Mask app
 
 3. **Direct Install to System**
-   - Tap **Install** -> **Next**
+   - Tap **Install** → **Next**
    - Select **"Direct Install to /system"**
    - If this option is missing, close and reopen the Kitsune Mask app
    - Let installation complete and reboot when prompted
@@ -111,22 +138,33 @@ Output will be in the `dist/` folder.
    - **Leave "Toggle R/W" ON**
 
 5. **Verify**
-   - Launch instance and open Kitsune Mask
-   - Should show as installed and active
+   - Launch the instance and open Kitsune Mask
+   - It should show as installed and active
+
+### Keep Root After Updates
+
+Root sticks across normal restarts, but a background **BlueStacks auto-update can silently replace the patched files and bring the security check back**. If that happens, just re-run "Patch BlueStacks Engine." To stop it from happening, disable the two update paths (Administrator terminal):
+
+```powershell
+sc.exe stop BstHdUpdaterSvc
+sc.exe config BstHdUpdaterSvc start= disabled
+schtasks /Change /TN "BlueStacksHelper_nxt" /DISABLE
+```
+
+> [!WARNING]
+> Disabling **both** matters. The `BstHdUpdaterSvc` service is the obvious one, but BlueStacks also runs a scheduled task (`BlueStacksHelper_nxt`) that can update independently — disabling only the service isn't enough. Setting `bst.auto_update="0"` in `bluestacks.conf` does **not** work; it is silently ignored.
 
 ## Troubleshooting
 
 ### Version Compatibility
 
-This fork **adds root support for BlueStacks 5.22**, which the upstream tool could not root. On 5.22 builds that enforce the integrity / disk-verification check, the GUI patches the engine (`HD-Player.exe`) to disable the *"Android system doesn't meet security"* tamper shutdown; on **5.22.150.1014+** it also patches the guest `su` inside each instance's `Data.vhdx`.
-
-| BlueStacks Version | Root Working? | Notes |
-|-------------------|---------------|-------|
-| 5.20.x - 5.21.x | Yes | Classic `enable_root_access` rooting |
-| 5.22.x (pre-5.22.150.1014) | Yes | Classic rooting; engine integrity patch clears the security popup |
+| BlueStacks Version | Root Working? | Method |
+|-------------------|---------------|--------|
+| 5.20.x – 5.21.x | Yes | Classic `enable_root_access` rooting |
+| 5.22.x (pre-5.22.150.1014) | Yes | Classic rooting + engine integrity patch to clear the security popup |
 | 5.22.150.1014+ | Yes | Patch mode: engine patch + `Data.vhdx` guest-`su` patch |
 
-**Verified rooted** - every instance reports `uid=0` after toggling root:
+**Verified rooted** — every instance reports `uid=0` after toggling root:
 
 | Edition | Registry key | Version | Mode | Android versions verified |
 |---------|--------------|---------|------|---------------------------|
@@ -139,16 +177,18 @@ This fork **adds root support for BlueStacks 5.22**, which the upstream tool cou
 <details>
 <summary><b>Background: the 5.22 "security" popup</b></summary>
 
-**Issue:** BlueStacks 5.22+ (October 2025) shows *"Android system doesn't meet security"* when root/R/W is enabled.
+**Issue:** BlueStacks 5.22+ (October 2025) shows *"Android system doesn't meet security requirements"* and shuts the instance down when root/R/W is enabled.
 
-**Cause:** Google replaced SafetyNet with the Play Integrity API in January 2025. BlueStacks 5.22 enforces integrity checks that detect system modifications.
+**Cause:** Google replaced SafetyNet with the Play Integrity API in January 2025. BlueStacks 5.22 added a disk-integrity check that detects the modified system and refuses to boot it.
 
-**Fix:** This GUI's engine patch disables that check, so downgrading to 5.21 is no longer required. Downgrade instructions are kept below for reference.
+**Fix:** This tool's engine patch disables that check, so downgrading to 5.21 is no longer required. Downgrade instructions are kept below only for reference.
 
 </details>
 
 <details>
-<summary><b>How to Downgrade to 5.21</b></summary>
+<summary><b>How to Downgrade to 5.21 (legacy)</b></summary>
+
+You should not need this anymore — it's kept for reference only.
 
 1. **Backup your data** - Export important app data/saves
 
@@ -160,40 +200,41 @@ This fork **adds root support for BlueStacks 5.22**, which the upstream tool cou
    - Download from **[Uptodown Archive](https://bluestacks-app-player.en.uptodown.com/windows/versions)**
    - Look for version **5.21.x.xxxx** (January 2025)
 
-4. **Disable auto-updates**
-   - Open `services.msc` (Win+R → type `services.msc`)
-   - Find **"BlueStacks Updater Service"** (`BstHdUpdaterSvc`)
-   - Right-click → Properties → Set Startup type to **Disabled** → Stop the service
-   - ~~`bst.auto_update="0"` in bluestacks.conf does **not** work — it is silently ignored~~
+4. **Disable auto-updates** - see [Keep Root After Updates](#keep-root-after-updates)
 
-5. **Apply rooting guide** - Follow normal steps above
+5. **Apply rooting guide** - follow the classic-build steps above
 
 </details>
 
-**Tracking:** See [Issue #11](https://github.com/RobThePCGuy/Root-Bluestacks-with-Kitsune-Mask/issues/11) for updates.
+**Tracking:** See [Issue #11](https://github.com/RobThePCGuy/Root-Bluestacks-with-Kitsune-Mask/issues/11) for history and discussion.
 
 ### Common Issues
 
 **No instances listed / "Path Not Found"**
-- Run GUI as **Administrator**
+- Run the GUI as **Administrator**
 - Verify registry keys exist: `HKLM\SOFTWARE\BlueStacks_nxt` (Normal), `HKLM\SOFTWARE\BlueStacks_nxt_cn` (China), or `HKLM\SOFTWARE\BlueStacks_msi5` (MSI)
-- Perform clean reinstall using official cleaner tool
+- Perform a clean reinstall using the official cleaner tool
 
-**Permission errors during toggle**
-- Must run as Administrator
+**"Permission denied" while patching `HD-MultiInstanceManager.exe`**
+- This means the Multi-Instance Manager window was open, locking the file. The tool now closes it automatically before patching — make sure you're on the latest version, then re-run "Patch BlueStacks Engine."
+
+**"Toggle Root" says `su` isn't in `Data.vhdx` yet**
+- The guest `su` only materializes after the instance's first boot. Start the instance once, shut it down, and toggle root again.
+
+**Root worked, then stopped after a while**
+- BlueStacks likely auto-updated and reverted the patch. Re-run "Patch BlueStacks Engine," then follow [Keep Root After Updates](#keep-root-after-updates).
 
 **R/W toggle doesn't persist**
-- Ensure BlueStacks processes were fully terminated
-- Manually kill processes via Task Manager if needed
+- Ensure BlueStacks processes were fully terminated (kill leftovers in Task Manager if needed)
 - Keep R/W **ON** after installing Kitsune Mask
 
 **"Direct Install to /system" option missing**
-- Verify both **Root** and **R/W** are ON before launching instance
-- Close and reopen Kitsune Mask app within BlueStacks
+- Verify both **Root** and **R/W** are ON before launching the instance
+- Close and reopen the Kitsune Mask app within BlueStacks
 
 **Toggle operation errors**
-- Check status bar in GUI for error messages
-- Review console logs if running from source
+- Check the status bar in the GUI for the error message
+- A full log is written to `%TEMP%\BlueStacksRootGUI.log` — helpful when reporting an issue
 
 ## Development
 
@@ -202,10 +243,11 @@ This fork **adds root support for BlueStacks 5.22**, which the upstream tool cou
 - `main.py` - PyQt5 GUI, application logic, threading
 - `config_handler.py` - Reads/writes `bluestacks.conf`
 - `instance_handler.py` - Modifies `.bstk` files, handles processes
-- `registry_handler.py` - Reads BlueStacks paths from Windows Registry
-- `constants.py` - Shared constants (keys, filenames, modes)
-- `integrity_patch.py` / `root_persistence.py` - Engine patches (5.22+ integrity bypass, keep root enabled)
-- `su_patch_offline.py` - Patch-mode app root: flips guest `su` `isDeveloperMode` inside `Data.vhdx`
+- `registry_handler.py` - Reads BlueStacks paths and versions from the Windows Registry
+- `constants.py` - Shared constants (keys, filenames, modes, process list, patch-mode version cutoff)
+- `admin.py` - UAC elevation helpers (relaunch as administrator, network-drive-safe)
+- `integrity_patch.py` / `root_persistence.py` - Engine patches (5.22+ integrity bypass, keep root enabled) with `.prepatch.bak` backups
+- `su_patch.py` / `su_patch_offline.py` - Patch-mode app root: flips the guest `su` `isDeveloperMode` gate inside `Data.vhdx` (bundled VHD/VHDX + ext4 reader, no ADB required)
 - `ext4_symlink.py` - Classic/MSI app root: adds `/system/xbin/su` in `Root.vhd` via bundled `debugfs` (`tools/e2fsprogs/`)
 
 ### Dependencies
@@ -222,7 +264,7 @@ Contributions are welcome! Please:
 - Maintain existing code style and structure
 - Use the `logging` module for debugging output
 - Add/update docstrings for new or modified code
-- Use background threads for blocking operations to keep UI responsive
+- Use background threads for blocking operations to keep the UI responsive
 - Update `constants.py` for new configurable values
 - Submit pull requests with clear descriptions
 - Open an issue to discuss significant changes before implementing

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ schtasks /Change /TN "BlueStacksHelper_nxt" /DISABLE
 ```
 
 > [!WARNING]
-> Disabling **both** matters. The `BstHdUpdaterSvc` service is the obvious one, but BlueStacks also runs a scheduled task (`BlueStacksHelper_nxt`) that can update independently — disabling only the service isn't enough. Setting `bst.auto_update="0"` in `bluestacks.conf` does **not** work; it is silently ignored.
+> The scheduled task is the one that matters most. Some builds don't even install the `BstHdUpdaterSvc` service — the `sc.exe` lines will report *"service does not exist,"* which is fine — but they still ship the `BlueStacksHelper_nxt` scheduled task, which can update independently. Disable whichever exist. Setting `bst.auto_update="0"` in `bluestacks.conf` does **not** work; it is silently ignored.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Updates the README to match what now works, in the existing style.

- **Fixes the downgrade contradiction** — Prerequisites and install steps no longer tell users to install 5.21; leads with 'the latest build roots, no downgrade needed.'
- **Adds 'How It Works'** — explains classic vs patch-mode rooting.
- **Splits the Usage Guide** — separate patch-mode (5.22.150.1014+) and classic/MSI flows.
- **Adds 'Keep Root After Updates'** — disable `BstHdUpdaterSvc` **and** the `BlueStacksHelper_nxt` scheduled task; notes `bst.auto_update="0"` is ignored.
- **Notes the live result** — confirmed on 5.22.232.1002 / Android 13.
- Demotes the 5.21 downgrade steps to a labeled legacy reference; expands Common Issues; fixes the last-commit badge link to `master`.

No content removed that's still accurate — the verified-versions table, Kitsune steps, and collapsibles are preserved.