### PR TITLE
Show newer-layout instances + surface engine-patch state in the GUI

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -42,8 +42,17 @@ MODE_UNKNOWN = "Unknown"
 
 FASTBOOT_VDI = "fastboot.vdi"
 ROOT_VHD = "Root.vhd"
+DATA_VHDX = "Data.vhdx"
 
+# Disks whose Type= the R/W *toggle* flips. Only the system disks -- never
+# Data.vhdx (userdata), which must stay writable or the instance won't boot.
 FILES_TO_MODIFY_RW = [FASTBOOT_VDI, ROOT_VHD]
+
+# Disks read when *detecting* an instance's R/W state. Newer BlueStacks
+# instances (created/cloned) ship a single Data.vhdx and no fastboot.vdi/
+# Root.vhd, so their .bstk only references Data.vhdx. We include it here so
+# such instances are recognized (and listed) instead of coming back "Unknown".
+RW_DETECT_FILES = [FASTBOOT_VDI, ROOT_VHD, DATA_VHDX]
 
 
 ANDROID_BSTK_IN_FILE = "Android.bstk.in"

--- a/instance_handler.py
+++ b/instance_handler.py
@@ -201,7 +201,7 @@ def is_instance_readonly(instance_path: str) -> Optional[bool]:
 
                     if any(
                         target_file in line
-                        for target_file in constants.FILES_TO_MODIFY_RW
+                        for target_file in constants.RW_DETECT_FILES
                     ):
                         found_relevant_line = True
 
@@ -228,7 +228,7 @@ def is_instance_readonly(instance_path: str) -> Optional[bool]:
     else:
 
         logger.warning(
-            f"No configuration lines found for target disk files ({constants.FILES_TO_MODIFY_RW}) in instance {instance_path}. Cannot determine R/W status."
+            f"No configuration lines found for target disk files ({constants.RW_DETECT_FILES}) in instance {instance_path}. Cannot determine R/W status."
         )
         return None
 

--- a/integrity_patch.py
+++ b/integrity_patch.py
@@ -338,6 +338,37 @@ def restore_file(path: str) -> bool:
     return True
 
 
+def is_file_patched(path: str, spec: PatchSpec) -> Optional[bool]:
+    """Return True/False if ``spec`` is/ isn't applied to the binary at ``path``.
+
+    Returns None when the state is indeterminate (file missing/unreadable, or the
+    signature isn't found -- e.g. a build this patch doesn't apply to).
+    """
+    try:
+        with open(path, "rb") as fh:
+            data = bytearray(fh.read())
+    except OSError:
+        return None
+    hits = spec.locator(bytes(data)) if spec.locator is not None else _find_signature(data, spec.signature)
+    if len(hits) != 1:
+        return None
+    at = hits[0] + spec.patch_offset
+    return bytes(data[at:at + len(spec.patch_bytes)]) == spec.patch_bytes
+
+
+def installation_patched(install_dir: str) -> Optional[bool]:
+    """Whether this install's engine is currently patched.
+
+    True if ``HD-Player.exe`` carries the unlock patch, False if it doesn't, None
+    if it can't be determined (binary missing, or an unrecognized build). Cheap
+    enough to call on a UI refresh -- it just reads and scans one binary.
+    """
+    path = os.path.join(install_dir, "HD-Player.exe")
+    if not os.path.isfile(path):
+        return None
+    return is_file_patched(path, UNLOCK_PLAYER)
+
+
 def patch_installation(install_dir: str, restore: bool = False) -> List[str]:
     """Patch (or restore) every candidate binary found in ``install_dir``.
 

--- a/main.py
+++ b/main.py
@@ -145,9 +145,18 @@ class BluestacksRootToggle(QWidget):
         )
         self.restore_button.clicked.connect(self.handle_restore_patches)
         main_layout.addWidget(self.restore_button)
+
+        # Shows whether the engine binaries are currently patched, so you don't
+        # have to guess. The engine patch is per-install (shared by every
+        # instance), so this reflects the whole installation, not a single one.
+        self.engine_status_label = QLabel("")
+        self.engine_status_label.setAlignment(Qt.AlignCenter)
+        main_layout.addWidget(self.engine_status_label)
+
         # Visibility is decided once installations are read (see _refresh_patch_ui).
         self.patch_button.setVisible(False)
         self.restore_button.setVisible(False)
+        self.engine_status_label.setVisible(False)
 
         self.status_label = QLabel("Ready")
         self.status_label.setAlignment(Qt.AlignCenter)
@@ -175,10 +184,29 @@ class BluestacksRootToggle(QWidget):
         self.status_refresh_timer.start(constants.REFRESH_INTERVAL_MS)
 
     def _refresh_patch_ui(self) -> None:
-        """Show the engine-patch buttons only when a 5.22.150.1014+ install exists."""
+        """Show the engine-patch buttons + status only when a 5.22.150.1014+ install exists."""
         has_patch_build = any(i.get("patch_mode") for i in self.installations)
         self.patch_button.setVisible(has_patch_build)
         self.restore_button.setVisible(has_patch_build)
+        self.engine_status_label.setVisible(has_patch_build)
+        if has_patch_build:
+            text, color = self._engine_status()
+            self.engine_status_label.setText(text)
+            self.engine_status_label.setStyleSheet(f"color: {color}; font-weight: bold;")
+
+    def _engine_status(self):
+        """(label, color) describing whether the engine is patched across installs."""
+        states = [integrity_patch.installation_patched(i["install_path"])
+                  for i in self.installations
+                  if i.get("patch_mode") and i.get("install_path")
+                  and os.path.isdir(i["install_path"])]
+        if states and all(s is True for s in states):
+            return "Engine: Patched ✓  (applies to every instance)", "#2e7d32"
+        if states and all(s is False for s in states):
+            return "Engine: Not patched — click \"Patch BlueStacks Engine\" once", "#c62828"
+        if any(s is True for s in states):
+            return "Engine: Partially patched — re-run \"Patch BlueStacks Engine\"", "#e65100"
+        return "Engine: status unknown (unrecognized build?)", "#616161"
 
     def update_instance_data(self) -> None:
         if not self.installations: return
@@ -424,6 +452,7 @@ class BluestacksRootToggle(QWidget):
         self.status_label.setText(summary if ok else f"Error: {summary}")
         logger.info("Operation finished (ok=%s): %s", ok, summary)
         self.update_instance_statuses(preserve_selection=True)
+        self._refresh_patch_ui()  # reflect the new engine-patch state after a patch/restore
         self.status_refresh_timer.start(constants.REFRESH_INTERVAL_MS)
 
     def _cleanup_async(self):


### PR DESCRIPTION
Two gaps found while using the tool on 5.22.232.1002:

**1. Created/cloned instances didn't show up.** Newer BlueStacks instances use a single `Data.vhdx` (`type="Normal"`) and no `fastboot.vdi`/`Root.vhd`, so their `.bstk` only references `Data.vhdx`. The R/W detection only looked for `fastboot.vdi`/`Root.vhd`, found nothing, returned `Unknown`, and the GUI filtered the instance out entirely.
- `is_instance_readonly()` now reads `Data.vhdx` too via a new `RW_DETECT_FILES`.
- The R/W **toggle** (`FILES_TO_MODIFY_RW`) is deliberately unchanged — it still only flips the system disks, never `Data.vhdx` (userdata), which must stay writable or the instance won't boot.
- Verified against real instances: clone `Tiramisu64_1` now detects **READWRITE** and lists; `Manager`/`UserData` junk folders still correctly filtered.

**2. No way to tell if the engine is patched.** Added `integrity_patch.installation_patched()` (reads `HD-Player.exe` and checks the unlock-patch bytes) and an **Engine: Patched ✓ / Not patched** status label under the patch buttons, refreshed on load and after every patch/restore. It notes the patch is per-install and applies to every instance.

Compile + ruff clean; logic functionally verified on-device.