### PR TITLE
Popup to boot the instance before rooting; quiet 5s refresh warnings

### DIFF
--- a/instance_handler.py
+++ b/instance_handler.py
@@ -183,7 +183,9 @@ def is_instance_readonly(instance_path: str) -> Optional[bool]:
         return None
 
     if not bstk_files_to_check:
-        logger.warning(
+        # Normal for BlueStacks' own non-instance folders (Manager, UserData);
+        # debug-level so the 5s status refresh doesn't spam warnings.
+        logger.debug(
             f"No .bstk files found to check readonly status in {instance_path}"
         )
         return None
@@ -227,7 +229,7 @@ def is_instance_readonly(instance_path: str) -> Optional[bool]:
         return False
     else:
 
-        logger.warning(
+        logger.debug(
             f"No configuration lines found for target disk files ({constants.RW_DETECT_FILES}) in instance {instance_path}. Cannot determine R/W status."
         )
         return None

--- a/main.py
+++ b/main.py
@@ -76,6 +76,9 @@ class _OpWorker(QObject):
 class BluestacksRootToggle(QWidget):
     """Main application window for toggling BlueStacks root and R/W settings."""
 
+    # Emitted from the worker thread to surface a modal notice on the UI thread.
+    show_notice = pyqtSignal(str, str)  # (title, message)
+
     def __init__(self):
         super().__init__()
         self.installations: List[registry_handler.Installation] = []
@@ -83,6 +86,8 @@ class BluestacksRootToggle(QWidget):
         self.instance_checkboxes: Dict[str, Dict[str, Any]] = {}
         self.is_toggling: bool = False
 
+        # Queued (cross-thread) so background jobs can pop a dialog safely.
+        self.show_notice.connect(self._show_notice)
         self.setWindowTitle(constants.APP_NAME)
         self._set_icon()
         self.status_refresh_timer = QTimer(self)
@@ -323,6 +328,17 @@ class BluestacksRootToggle(QWidget):
             if progress:
                 progress("Part 2/2: patching guest su in Data.vhdx...")
             results = su_patch_offline.set_instance_root(instance["data_path"], True, progress)
+            # If no guest su was patched (sidecar not written), Android hasn't
+            # generated su yet -- the instance must be booted once first. This is
+            # easy to miss in the status bar, so tell the user with a dialog.
+            if not su_patch_offline.instance_root_state(instance["data_path"]):
+                self.show_notice.emit(
+                    "Boot this instance once first",
+                    "%s hasn't generated its root files yet, so there was nothing "
+                    "to patch.\n\nStart this instance in BlueStacks, let it fully "
+                    "reach the home screen, then close it completely and click "
+                    "\"Toggle Root\" again." % unique_id,
+                )
         else:
             if progress:
                 progress("Part 1/2: restoring guest su in Data.vhdx...")
@@ -446,6 +462,11 @@ class BluestacksRootToggle(QWidget):
 
     def _on_async_progress(self, msg):
         self.status_label.setText(msg)
+
+    @pyqtSlot(str, str)
+    def _show_notice(self, title, message):
+        """Show a modal info dialog. Runs on the UI thread via a queued signal."""
+        QMessageBox.information(self, title, message)
 
     def _on_async_done(self, ok, summary):
         self._set_busy(False)


### PR DESCRIPTION
**Popup:** toggling root on a patch-mode instance that hasn't been booted yet finds 0 guest `su` to patch (Android only creates `su` in `Data.vhdx` after the first boot). The existing 'boot the instance once and retry' notice only appeared in the status bar and was easy to miss. Now a modal dialog says it plainly. Detected reliably by checking that the backup sidecar wasn't written (no su patched), and shown on the UI thread via a queued `show_notice` signal so it's safe to raise from the background worker.

**Log noise:** the R/W check logged a warning for every folder without recognized disks on **every 5-second refresh** — normal for BlueStacks' own `Manager`/`UserData` folders. Dropped those two messages to debug level.

Compile + ruff clean.