### PR TITLE
Release prep v3.0.0: dead-code cleanup, safe polish, release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+# Build the Windows executable and publish a GitHub Release whenever a
+# version tag (e.g. v3.0.0) is pushed. Can also be run manually to produce
+# a build artifact without cutting a release.
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pyinstaller
+
+      - name: Build executable
+        run: >
+          pyinstaller --onefile --windowed
+          --icon="favicon.ico"
+          --add-data "favicon.ico;."
+          --add-data "tools/e2fsprogs;tools/e2fsprogs"
+          --name BlueStacksRootGUI main.py
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: BlueStacksRootGUI
+          path: dist/BlueStacksRootGUI.exe
+          if-no-files-found: error
+
+      - name: Publish release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/BlueStacksRootGUI.exe
+          generate_release_notes: true

--- a/admin.py
+++ b/admin.py
@@ -73,21 +73,6 @@ def to_accessible_path(path: str) -> str:
             logger.debug("Drive-type check failed for %s", drive, exc_info=True)
     return abspath
 
-
-def is_network_path(path: str) -> bool:
-    """True if ``path`` resolves to a UNC path or a mapped network drive."""
-    abspath = os.path.abspath(path)
-    if abspath.startswith("\\\\"):
-        return True
-    drive, _ = os.path.splitdrive(abspath)
-    if len(drive) == 2 and drive[1] == ":":
-        try:
-            return ctypes.windll.kernel32.GetDriveTypeW(drive + "\\") == 4
-        except Exception:  # noqa: BLE001
-            return False
-    return False
-
-
 def relaunch_as_admin() -> bool:
     """Relaunch the current program elevated via a UAC prompt.
 

--- a/config_handler.py
+++ b/config_handler.py
@@ -1,8 +1,10 @@
 """Configuration file handling utilities."""
+from __future__ import annotations
+
 import os
 import logging
 import re
-from typing import Dict, Any
+from typing import Any
 
 
 import constants
@@ -26,11 +28,11 @@ def modify_config_file(config_path: str, setting: str, new_value: str) -> bool:
     new_line_content = f'{setting}="{new_value}"'
     lines = []
     try:
-        with open(config_path, "r", encoding="utf-8") as file:
+        with open(config_path, encoding="utf-8") as file:
             lines = file.readlines()
     except Exception as e:
         logger.exception(f"Error reading configuration file {config_path}")
-        raise IOError(f"Error reading configuration file {config_path}: {e}") from e
+        raise OSError(f"Error reading configuration file {config_path}: {e}") from e
 
     updated_lines = []
     setting_found_and_updated = False
@@ -74,14 +76,14 @@ def modify_config_file(config_path: str, setting: str, new_value: str) -> bool:
             logger.debug(f"Successfully wrote changes to {config_path}")
         except Exception as e:
             logger.exception(f"Error writing updated configuration file {config_path}")
-            raise IOError(
+            raise OSError(
                 f"Error writing updated configuration file {config_path}: {e}"
             ) from e
 
     return changed
 
 
-def get_complete_root_statuses(config_path: str) -> Dict[str, Any]:
+def get_complete_root_statuses(config_path: str) -> dict[str, Any]:
     """
     Reads a config file and returns all instance root statuses AND the global rooting feature status.
 
@@ -91,7 +93,7 @@ def get_complete_root_statuses(config_path: str) -> Dict[str, Any]:
     Returns:
         A dictionary like: {'global_status': bool, 'instance_statuses': {name: bool}}
     """
-    instance_statuses: Dict[str, bool] = {}
+    instance_statuses: dict[str, bool] = {}
     global_status: bool = False
 
     if not os.path.isfile(config_path):
@@ -114,15 +116,15 @@ def get_complete_root_statuses(config_path: str) -> Dict[str, Any]:
     )
 
     try:
-        with open(config_path, "r", encoding="utf-8") as file:
+        with open(config_path, encoding="utf-8") as file:
             for line in file:
                 stripped_line = line.strip()
-                
+
                 # Check for global key
                 if global_pattern.match(stripped_line):
                     global_status = True
                     logger.debug(f"Found global root status in {config_path}: Enabled")
-                
+
                 # Check for instance key
                 match = instance_pattern.match(stripped_line)
                 if match:

--- a/constants.py
+++ b/constants.py
@@ -1,4 +1,6 @@
 """Application constants."""
+from __future__ import annotations
+
 import re
 
 INSTANCE_PREFIX = "bst.instance."
@@ -89,6 +91,7 @@ PROCESS_KILL_TIMEOUT_S = 5
 PROCESS_POST_KILL_WAIT_S = 2
 
 
-APP_ID = "RobThePCGuy.BlueStacksRootGUI.2.6"
+APP_VERSION = "3.0.0"
+APP_ID = f"RobThePCGuy.BlueStacksRootGUI.{APP_VERSION}"
 APP_NAME = "BlueStacks Root GUI"
 ICON_FILENAME = "favicon.ico"

--- a/ext4_symlink.py
+++ b/ext4_symlink.py
@@ -34,7 +34,6 @@ import subprocess
 import sys
 import tempfile
 import time
-from typing import List, Optional
 
 import su_patch_offline  # reuse its dynamic-VHD reader for the MBR probe
 
@@ -69,7 +68,7 @@ def tools_available() -> bool:
     return os.path.isfile(_debugfs()) and os.path.isfile(_e2fsck())
 
 
-def _run(args: List[str], env: Optional[dict] = None) -> subprocess.CompletedProcess:
+def _run(args: list[str], env: dict | None = None) -> subprocess.CompletedProcess:
     return subprocess.run(args, capture_output=True, text=True,
                           creationflags=_NO_WINDOW, env=env)
 
@@ -128,7 +127,7 @@ def _detach(vhd_path: str) -> None:
     _diskpart('select vdisk file="%s"\ndetach vdisk\n' % vhd_path)
 
 
-def _disk_number(vhd_path: str) -> Optional[int]:
+def _disk_number(vhd_path: str) -> int | None:
     """OS disk number of the attached VHD (== PhysicalDriveN index)."""
     r = _run(["powershell", "-NoProfile", "-Command",
               "(Get-Disk | Where-Object { $_.Location -eq '%s' }).Number" % vhd_path])
@@ -142,7 +141,7 @@ def _cyg_device(disk_number: int, offset: int) -> str:
     return "/dev/sd%s?offset=%d" % (chr(ord("a") + disk_number), offset)
 
 
-def _find_xbin(device: str, env: dict) -> Optional[str]:
+def _find_xbin(device: str, env: dict) -> str | None:
     """Return the xbin dir (from _XBIN_CANDIDATES) that holds bstk/su, or None."""
     for xbin in _XBIN_CANDIDATES:
         r = _run([_debugfs(), "-R", "stat %s/bstk/su" % xbin, device], env=env)
@@ -167,9 +166,9 @@ class _Attached:
     def __init__(self, vhd_path: str):
         self.vhd = vhd_path
         self.offset = _partition_offset(vhd_path)
-        self.device: Optional[str] = None
+        self.device: str | None = None
 
-    def __enter__(self) -> "_Attached":
+    def __enter__(self) -> _Attached:
         _attach(self.vhd)
         time.sleep(1.5)  # let Windows enumerate the disk
         num = _disk_number(self.vhd)
@@ -182,21 +181,7 @@ class _Attached:
     def __exit__(self, *exc) -> None:
         _detach(self.vhd)
 
-
-def has_su_symlink(instance_dir: str) -> bool:
-    """True if ``/system/xbin/su`` already exists in this instance's Root.vhd."""
-    vhd = _root_vhd(instance_dir)
-    if not (tools_available() and os.path.isfile(vhd)):
-        return False
-    env = _tool_env()
-    with _Attached(vhd) as att:
-        xbin = _find_xbin(att.device, env)
-        if not xbin:
-            return False
-        return "Type: symlink" in _stat_su(att.device, xbin, env)
-
-
-def add_su_symlink(instance_dir: str, progress=None) -> List[str]:
+def add_su_symlink(instance_dir: str, progress=None) -> list[str]:
     """Create ``/system/xbin/su -> bstk/su`` in a shut-down instance's Root.vhd.
 
     Idempotent; returns human-readable status lines.  Raises on hard failure
@@ -214,7 +199,7 @@ def add_su_symlink(instance_dir: str, progress=None) -> List[str]:
         raise RuntimeError("Root.vhd not found in %s" % instance_dir)
 
     env = _tool_env()
-    results: List[str] = []
+    results: list[str] = []
     _p("Attaching Root.vhd (app-root symlink)...")
     with _Attached(vhd) as att:
         dev = att.device
@@ -226,10 +211,10 @@ def add_su_symlink(instance_dir: str, progress=None) -> List[str]:
             results.append("%s/su already present" % xbin)
             return results
         _p("Creating %s/su -> %s..." % (xbin, _LINK_TARGET))
-        cmds = ("symlink {x}/{n} {t}\n"
-                "sif {x}/{n} uid 0\n"
-                "sif {x}/{n} gid 0\n"
-                "quit\n").format(x=xbin, n=_LINK_NAME, t=_LINK_TARGET)
+        cmds = (f"symlink {xbin}/{_LINK_NAME} {_LINK_TARGET}\n"
+                f"sif {xbin}/{_LINK_NAME} uid 0\n"
+                f"sif {xbin}/{_LINK_NAME} gid 0\n"
+                "quit\n")
         fd, cf = tempfile.mkstemp(suffix=".txt")
         try:
             with os.fdopen(fd, "w") as f:
@@ -249,7 +234,7 @@ def add_su_symlink(instance_dir: str, progress=None) -> List[str]:
     return results
 
 
-def remove_su_symlink(instance_dir: str, progress=None) -> List[str]:
+def remove_su_symlink(instance_dir: str, progress=None) -> list[str]:
     """Remove the injected ``/system/xbin/su`` symlink (if present)."""
     def _p(msg: str) -> None:
         logger.info(msg)
@@ -260,7 +245,7 @@ def remove_su_symlink(instance_dir: str, progress=None) -> List[str]:
     if not tools_available() or not os.path.isfile(vhd):
         return ["e2fsprogs/Root.vhd unavailable -- nothing to remove"]
     env = _tool_env()
-    results: List[str] = []
+    results: list[str] = []
     _p("Attaching Root.vhd (remove app-root symlink)...")
     with _Attached(vhd) as att:
         dev = att.device

--- a/instance_handler.py
+++ b/instance_handler.py
@@ -1,9 +1,10 @@
 """Operations related to BlueStacks instances."""
+from __future__ import annotations
+
 import os
 import glob
 import logging
 import psutil
-from typing import List, Optional
 
 
 import constants
@@ -37,7 +38,7 @@ def modify_instance_files(instance_path: str, new_mode: str) -> None:
     if not os.path.isdir(instance_path):
         raise FileNotFoundError(f"Instance directory not found: {instance_path}")
 
-    bstk_files_to_process: List[str] = []
+    bstk_files_to_process: list[str] = []
     android_bstk_in_path = os.path.join(instance_path, constants.ANDROID_BSTK_IN_FILE)
 
     if os.path.exists(android_bstk_in_path):
@@ -62,7 +63,7 @@ def modify_instance_files(instance_path: str, new_mode: str) -> None:
     except Exception as e:
         logger.error(f"Error finding .bstk files in {instance_path}: {e}")
 
-        raise IOError(f"Error finding .bstk files in {instance_path}") from e
+        raise OSError(f"Error finding .bstk files in {instance_path}") from e
 
     if not bstk_files_to_process:
 
@@ -84,7 +85,7 @@ def modify_instance_files(instance_path: str, new_mode: str) -> None:
         logger.debug(f"Processing file: {bstk_file_path}")
         try:
 
-            with open(bstk_file_path, "r", encoding="utf-8") as f:
+            with open(bstk_file_path, encoding="utf-8") as f:
                 content = f.readlines()
 
             updated_content = []
@@ -132,7 +133,7 @@ def modify_instance_files(instance_path: str, new_mode: str) -> None:
 
             logger.error(f"File disappeared during processing: {bstk_file_path}")
             raise
-        except IOError:
+        except OSError:
             logger.exception(f"I/O error processing file {bstk_file_path}")
             raise
         except Exception:
@@ -140,7 +141,7 @@ def modify_instance_files(instance_path: str, new_mode: str) -> None:
             raise
 
 
-def is_instance_readonly(instance_path: str) -> Optional[bool]:
+def is_instance_readonly(instance_path: str) -> bool | None:
     """
     Checks if any relevant disk file (.vdi, .vhd) is explicitly set to 'Readonly'
     in the instance's .bstk files.
@@ -161,7 +162,7 @@ def is_instance_readonly(instance_path: str) -> Optional[bool]:
         )
         return None
 
-    bstk_files_to_check: List[str] = []
+    bstk_files_to_check: list[str] = []
     android_bstk_in_path = os.path.join(instance_path, constants.ANDROID_BSTK_IN_FILE)
     if os.path.exists(android_bstk_in_path):
         bstk_files_to_check.append(android_bstk_in_path)
@@ -198,7 +199,7 @@ def is_instance_readonly(instance_path: str) -> Optional[bool]:
     for file_path in bstk_files_to_check:
         logger.debug(f"Scanning file for readonly check: {file_path}")
         try:
-            with open(file_path, "r", encoding="utf-8") as f:
+            with open(file_path, encoding="utf-8") as f:
                 for line_num, line in enumerate(f, 1):
 
                     if any(
@@ -234,37 +235,6 @@ def is_instance_readonly(instance_path: str) -> Optional[bool]:
         )
         return None
 
-
-def is_bluestacks_running() -> bool:
-    """
-    Checks if any known BlueStacks processes are running.
-
-    Returns:
-        True if at least one known BlueStacks process is found, False otherwise.
-    """
-    logger.debug("Checking for running BlueStacks processes...")
-    for proc in psutil.process_iter(["name"]):
-        try:
-
-            proc_name = proc.info["name"]
-            if proc_name in constants.BLUESTACKS_PROCESS_NAMES:
-                logger.info(
-                    f"Detected running BlueStacks process: {proc_name} (PID: {proc.pid})"
-                )
-                return True
-        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess) as e:
-
-            logger.debug(f"Skipping process check for PID {proc.pid}: {e}")
-            continue
-        except Exception as e:
-
-            logger.exception(f"Unexpected error checking process {proc.pid}: {e}")
-            continue
-
-    logger.debug("No running BlueStacks processes found matching the known list.")
-    return False
-
-
 def terminate_bluestacks() -> bool:
     """
     Attempts to terminate all known BlueStacks-related processes gracefully,
@@ -276,7 +246,7 @@ def terminate_bluestacks() -> bool:
     """
     terminated_any = False
     logger.info("Attempting to terminate BlueStacks processes...")
-    processes_found: List[psutil.Process] = []
+    processes_found: list[psutil.Process] = []
 
     for proc in psutil.process_iter(["pid", "name"]):
         try:

--- a/integrity_patch.py
+++ b/integrity_patch.py
@@ -47,7 +47,7 @@ import shutil
 import struct
 import sys
 from dataclasses import dataclass
-from typing import Callable, List, Optional, Tuple
+from typing import Callable
 
 logger = logging.getLogger(__name__)
 
@@ -83,12 +83,12 @@ class PatchSpec:
     patch_offset: int
     expect_bytes: bytes
     patch_bytes: bytes
-    signature: Optional[List[Optional[int]]] = None
-    locator: Optional[Callable[[bytes], List[int]]] = None
+    signature: list[int | None] | None = None
+    locator: Callable[[bytes], list[int]] | None = None
 
 
 # --- Minimal PE helpers (for locators that must resolve RIP-relative refs) ---
-def pe_image_base_and_sections(data: bytes) -> Tuple[int, List[Tuple[int, int, int, int]]]:
+def pe_image_base_and_sections(data: bytes) -> tuple[int, list[tuple[int, int, int, int]]]:
     """Parse just enough PE to map file offsets <-> RVAs.
 
     Returns ``(image_base, sections)`` where each section is
@@ -116,7 +116,7 @@ def pe_image_base_and_sections(data: bytes) -> Tuple[int, List[Tuple[int, int, i
     return image_base, sections
 
 
-def file_offset_to_rva(sections, foff: int) -> Optional[int]:
+def file_offset_to_rva(sections, foff: int) -> int | None:
     """Map a raw file offset to its RVA, or None if outside any raw section."""
     for va, _vsize, praw, sraw in sections:
         if praw <= foff < praw + sraw:
@@ -141,9 +141,9 @@ DISK_INTEGRITY_CALL = PatchSpec(
 )
 
 
-def _find_signature(data: bytes, sig: List[Optional[int]]) -> List[int]:
+def _find_signature(data: bytes, sig: list[int | None]) -> list[int]:
     """Return every start offset in ``data`` matching ``sig`` (None = wildcard)."""
-    hits: List[int] = []
+    hits: list[int] = []
     first = sig[0]
     assert first is not None, "signature must start with a concrete byte"
     n = len(sig)
@@ -165,7 +165,7 @@ _ISDVR_PROLOGUE = bytes([0x48, 0x89, 0x5C, 0x24, 0x08,
                          0x48, 0x89, 0x7C, 0x24, 0x18])
 
 
-def _locate_isdiskverify(data: bytes) -> List[int]:
+def _locate_isdiskverify(data: bytes) -> list[int]:
     """Locate _isDiskVerificationRequired() via its 'unlock_player.bin' reference.
 
     That function reads the signed unlock file and returns 0 only when a valid
@@ -251,7 +251,7 @@ def _apply_to_buffer(data: bytearray, spec: PatchSpec) -> str:
     return f"patched at 0x{at:X}: {current.hex(' ')} -> {spec.patch_bytes.hex(' ')}"
 
 
-def patch_file(path: str, specs: List[PatchSpec] = (DISK_INTEGRITY_CALL,),
+def patch_file(path: str, specs: list[PatchSpec] = (DISK_INTEGRITY_CALL,),
                make_backup: bool = True) -> bool:
     """Patch a single executable. Returns True if any change was written."""
     with open(path, "rb") as fh:
@@ -338,7 +338,7 @@ def restore_file(path: str) -> bool:
     return True
 
 
-def is_file_patched(path: str, spec: PatchSpec) -> Optional[bool]:
+def is_file_patched(path: str, spec: PatchSpec) -> bool | None:
     """Return True/False if ``spec`` is/ isn't applied to the binary at ``path``.
 
     Returns None when the state is indeterminate (file missing/unreadable, or the
@@ -356,7 +356,7 @@ def is_file_patched(path: str, spec: PatchSpec) -> Optional[bool]:
     return bytes(data[at:at + len(spec.patch_bytes)]) == spec.patch_bytes
 
 
-def installation_patched(install_dir: str) -> Optional[bool]:
+def installation_patched(install_dir: str) -> bool | None:
     """Whether this install's engine is currently patched.
 
     True if ``HD-Player.exe`` carries the unlock patch, False if it doesn't, None
@@ -369,12 +369,12 @@ def installation_patched(install_dir: str) -> Optional[bool]:
     return is_file_patched(path, UNLOCK_PLAYER)
 
 
-def patch_installation(install_dir: str, restore: bool = False) -> List[str]:
+def patch_installation(install_dir: str, restore: bool = False) -> list[str]:
     """Patch (or restore) every candidate binary found in ``install_dir``.
 
     Returns a list of status lines for display in a UI/log.
     """
-    results: List[str] = []
+    results: list[str] = []
     for name in CANDIDATE_BINARIES:
         path = os.path.join(install_dir, name)
         if not os.path.isfile(path):
@@ -398,7 +398,7 @@ def patch_installation(install_dir: str, restore: bool = False) -> List[str]:
     return results
 
 
-def _main(argv: Optional[List[str]] = None) -> int:
+def _main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("install_dir",

--- a/main.py
+++ b/main.py
@@ -1,9 +1,11 @@
 """Qt5-based GUI application for toggling BlueStacks root access."""
+from __future__ import annotations
+
 import sys
 import os
 import logging
 import tempfile
-from typing import Dict, Any, Optional, List
+from typing import Any
 
 from PyQt5.QtWidgets import (
     QApplication,
@@ -81,14 +83,13 @@ class BluestacksRootToggle(QWidget):
 
     def __init__(self):
         super().__init__()
-        self.installations: List[registry_handler.Installation] = []
-        self.instance_data: Dict[str, Dict[str, Any]] = {}
-        self.instance_checkboxes: Dict[str, Dict[str, Any]] = {}
-        self.is_toggling: bool = False
+        self.installations: list[registry_handler.Installation] = []
+        self.instance_data: dict[str, dict[str, Any]] = {}
+        self.instance_checkboxes: dict[str, dict[str, Any]] = {}
 
         # Queued (cross-thread) so background jobs can pop a dialog safely.
         self.show_notice.connect(self._show_notice)
-        self.setWindowTitle(constants.APP_NAME)
+        self.setWindowTitle(f"{constants.APP_NAME} v{constants.APP_VERSION}")
         self._set_icon()
         self.status_refresh_timer = QTimer(self)
         self.status_refresh_timer.timeout.connect(
@@ -216,7 +217,7 @@ class BluestacksRootToggle(QWidget):
     def update_instance_data(self) -> None:
         if not self.installations: return
 
-        all_found_instances: Dict[str, Dict[str, Any]] = {}
+        all_found_instances: dict[str, dict[str, Any]] = {}
         for inst in self.installations:
             source_id, config_path, data_path = inst["source"], inst["config_path"], inst["data_path"]
             patch_mode = inst.get("patch_mode", False)  # 5.22.150.1014+ uses the patches
@@ -485,7 +486,7 @@ class BluestacksRootToggle(QWidget):
         self._op_thread = None
 
     # ---- Engine patch (5.22.150.1014+) ------------------------------------
-    def _install_dirs_or_warn(self) -> Optional[List[str]]:
+    def _install_dirs_or_warn(self) -> list[str] | None:
         """Return BlueStacks install dirs, after ensuring admin rights.
 
         Returns None (and shows the appropriate dialog) if not elevated or no

--- a/registry_handler.py
+++ b/registry_handler.py
@@ -1,16 +1,18 @@
+from __future__ import annotations
+
 import winreg
 import logging
 import os
-from typing import List, Dict, Any
+from typing import Any
 
 import constants
 
 logger = logging.getLogger(__name__)
 
-Installation = Dict[str, Any]
+Installation = dict[str, Any]
 
-def get_all_bluestacks_installations() -> List[Installation]:
-    installations: List[Installation] = []
+def get_all_bluestacks_installations() -> list[Installation]:
+    installations: list[Installation] = []
     reg_sources = {
         constants.APP_SOURCE_NXT: constants.REGISTRY_BASE_PATH,
         constants.APP_SOURCE_NXT_CN: constants.REGISTRY_CN_BASE_PATH,

--- a/root_persistence.py
+++ b/root_persistence.py
@@ -28,7 +28,7 @@ import logging
 import os
 import struct
 from ctypes import wintypes
-from typing import Iterator, List
+from typing import Iterator
 
 import integrity_patch
 
@@ -139,7 +139,7 @@ _ROOT_WRITE_SHAPE = [0x4C, 0x8D, 0x05, None, None, None, None,  # lea r8, <strin
 _ROOT_WRITE_CALL_OFFSET = 28                                     # the E8 to NOP
 
 
-def _locate_enable_root_write(data: bytes) -> List[int]:
+def _locate_enable_root_write(data: bytes) -> list[int]:
     """Find the lea that loads ".enable_root_access" and feeds the write call."""
     try:
         image_base, sections = integrity_patch.pe_image_base_and_sections(data)
@@ -153,7 +153,7 @@ def _locate_enable_root_write(data: bytes) -> List[int]:
         return []
     str_va = image_base + str_rva
 
-    hits: List[int] = []
+    hits: list[int] = []
     for cand in integrity_patch._find_signature(bytearray(data), _ROOT_WRITE_SHAPE):
         lea_rva = integrity_patch.file_offset_to_rva(sections, cand)
         if lea_rva is None:
@@ -174,7 +174,7 @@ ROOT_RESET_NOP = integrity_patch.PatchSpec(
 )
 
 
-def patch_root_persistence(install_dir: str, restore: bool = False) -> List[str]:
+def patch_root_persistence(install_dir: str, restore: bool = False) -> list[str]:
     """Binary alternative to the read-only lock.
 
     Patches ``HD-MultiInstanceManager.exe`` so it no longer resets

--- a/su_patch.py
+++ b/su_patch.py
@@ -39,7 +39,6 @@ import os
 import shutil
 import struct
 import sys
-from typing import List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +48,7 @@ PATCH = bytes([0xB0, 0x01, 0xC3])
 PROLOGUE = bytes([0x53, 0x48, 0x8D])  # push rbx ; lea rdi, ... (observed prologue)
 
 
-def _elf_segments(data: bytes) -> Tuple[bool, List[Tuple[int, int, int]]]:
+def _elf_segments(data: bytes) -> tuple[bool, list[tuple[int, int, int]]]:
     """Return (is64, [(p_vaddr, p_offset, p_filesz)]) for PT_LOAD segments."""
     if data[:4] != b"\x7fELF":
         raise ValueError("not an ELF")
@@ -84,21 +83,13 @@ def _elf_segments(data: bytes) -> Tuple[bool, List[Tuple[int, int, int]]]:
     return is64, segs
 
 
-def _off_to_vaddr(segs, off: int) -> Optional[int]:
+def _off_to_vaddr(segs, off: int) -> int | None:
     for vaddr, foff, fsz in segs:
         if foff <= off < foff + fsz:
             return vaddr + (off - foff)
     return None
 
-
-def _vaddr_to_off(segs, vaddr: int) -> Optional[int]:
-    for v, foff, fsz in segs:
-        if v <= vaddr < v + fsz:
-            return foff + (vaddr - v)
-    return None
-
-
-def _find_isdevmode_entry(data: bytes) -> Optional[int]:
+def _find_isdevmode_entry(data: bytes) -> int | None:
     """File offset of the isDeveloperMode() entry, or None."""
     s = data.find(DEVMODE_STRING)
     if s < 0:

--- a/su_patch_offline.py
+++ b/su_patch_offline.py
@@ -26,7 +26,6 @@ import logging
 import os
 import struct
 import sys
-from typing import Dict, List, Optional, Tuple
 
 import su_patch  # DEVMODE_STRING, PATCH, _find_isdevmode_entry
 
@@ -92,7 +91,7 @@ class DynamicVHD:
     def is_present(self, blk: int) -> bool:
         return 0 <= blk < self.max_entries and self.bat[blk] != BAT_UNUSED
 
-    def _phys(self, flat: int) -> Optional[int]:
+    def _phys(self, flat: int) -> int | None:
         blk = flat // self.block_size
         if blk >= self.max_entries or self.bat[blk] == BAT_UNUSED:
             return None
@@ -116,9 +115,9 @@ class DynamicVHD:
     def write(self, flat: int, data: bytes) -> None:
         phys = self._phys(flat)
         if phys is None:
-            raise IOError("flat 0x%X not allocated" % flat)
+            raise OSError("flat 0x%X not allocated" % flat)
         if (flat % self.block_size) + len(data) > self.block_size:
-            raise IOError("write crosses block boundary")
+            raise OSError("write crosses block boundary")
         self.f.seek(phys)
         self.f.write(data)
 
@@ -145,7 +144,7 @@ class DynamicVHDX:
         if rhdr[:4] != b"regi":
             raise ValueError("bad VHDX region table")
         entry_count = struct.unpack_from("<I", rhdr, 8)[0]
-        regions: Dict[bytes, int] = {}
+        regions: dict[bytes, int] = {}
         for _ in range(entry_count):
             e = self.f.read(32)
             regions[e[:16]] = struct.unpack_from("<Q", e, 16)[0]
@@ -159,7 +158,7 @@ class DynamicVHDX:
         if mhdr[:8] != b"metadata":
             raise ValueError("bad VHDX metadata table")
         md_count = struct.unpack_from("<H", mhdr, 10)[0]
-        items: Dict[bytes, int] = {}
+        items: dict[bytes, int] = {}
         for _ in range(md_count):
             me = self.f.read(32)
             items[me[:16]] = struct.unpack_from("<I", me, 16)[0]  # offset in region
@@ -179,7 +178,7 @@ class DynamicVHDX:
         self.max_entries = (virtual_size + self.block_size - 1) // self.block_size
         # Payload BAT: every ``chunk_ratio`` payload entries are followed by one
         # sector-bitmap entry, so payload block N is BAT index N + N//chunk_ratio.
-        self._phys_off: List[Optional[int]] = []
+        self._phys_off: list[int | None] = []
         for blk in range(self.max_entries):
             idx = blk + blk // chunk_ratio
             self.f.seek(bat_off + idx * 8)
@@ -192,7 +191,7 @@ class DynamicVHDX:
     def is_present(self, blk: int) -> bool:
         return 0 <= blk < self.max_entries and self._phys_off[blk] is not None
 
-    def _phys(self, flat: int) -> Optional[int]:
+    def _phys(self, flat: int) -> int | None:
         blk = flat // self.block_size
         if not self.is_present(blk):
             return None
@@ -216,9 +215,9 @@ class DynamicVHDX:
     def write(self, flat: int, data: bytes) -> None:
         phys = self._phys(flat)
         if phys is None:
-            raise IOError("flat 0x%X not allocated" % flat)
+            raise OSError("flat 0x%X not allocated" % flat)
         if (flat % self.block_size) + len(data) > self.block_size:
-            raise IOError("write crosses block boundary")
+            raise OSError("write crosses block boundary")
         self.f.seek(phys)
         self.f.write(data)
 
@@ -235,7 +234,7 @@ def open_disk(path: str, writable: bool = False):
     return DynamicVHD(path, writable=writable)
 
 
-def _elf_size(hdr: bytes) -> Optional[int]:
+def _elf_size(hdr: bytes) -> int | None:
     """Total file size of the ELF whose header starts at hdr[0], or None."""
     if hdr[:4] != b"\x7fELF":
         return None
@@ -258,13 +257,13 @@ def _elf_size(hdr: bytes) -> Optional[int]:
 # string with the function. Each pattern starts AT the entry (first 3 bytes get
 # the b0 01 c3 patch). The build-specific rel32 keeps it unique. Derived from the
 # installer su binaries; None = wildcard.
-_FALLBACK_SIGS: List[List[Optional[int]]] = [
+_FALLBACK_SIGS: list[list[int | None]] = [
     # A9 (Android 9) static-64: push rbx; lea rdi,[rip+0xE66A8 -> isDevStr]; xor eax,eax; call
     [0x53, 0x48, 0x8D, 0x3D, 0xA8, 0x66, 0x0E, 0x00, 0x31, 0xC0, 0xE8],
 ]
 
 
-def _match_sig(hay: bytes, sig: List[Optional[int]], start: int) -> int:
+def _match_sig(hay: bytes, sig: list[int | None], start: int) -> int:
     n = len(sig)
     i = start
     first = sig[0]
@@ -342,7 +341,7 @@ def _classify_elf_su(elf: bytes, marker: bytes):
     return None
 
 
-def _scan_su_entries(vhd, pct=None) -> List[Tuple[int, bool, bool]]:
+def _scan_su_entries(vhd, pct=None) -> list[tuple[int, bool, bool]]:
     """Every gated su's isDeveloperMode entry as (flat_off, patched, is64).
 
     String-driven: locate each "isDeveloperMode" string, find the owning ELF, and
@@ -352,7 +351,7 @@ def _scan_su_entries(vhd, pct=None) -> List[Tuple[int, bool, bool]]:
     ext4 file is fragmented (string and function land far apart on disk).
     """
     marker = su_patch.DEVMODE_STRING
-    found: Dict[int, Tuple[bool, bool]] = {}      # flat_off -> (patched, is64)
+    found: dict[int, tuple[bool, bool]] = {}      # flat_off -> (patched, is64)
     seen_elf = set()
     prev_tail = b""
     tail_len = max(len(marker), max((len(s) for s in _FALLBACK_SIGS), default=0)) + 8
@@ -415,7 +414,7 @@ def _scan_su_entries(vhd, pct=None) -> List[Tuple[int, bool, bool]]:
     return sorted((off, p, a) for off, (p, a) in found.items())
 
 
-def _find_su_entries(vhd, pct=None) -> List[int]:
+def _find_su_entries(vhd, pct=None) -> list[int]:
     """Compat wrapper: flat offsets of UN-patched su entries (for dry-run)."""
     return [off for off, patched, _is64 in _scan_su_entries(vhd, pct) if not patched]
 
@@ -424,7 +423,7 @@ def _sidecar(vhd_path: str) -> str:
     return vhd_path + ".suroot.json"
 
 
-def enable(vhd_path: str, progress=None) -> List[str]:
+def enable(vhd_path: str, progress=None) -> list[str]:
     """Patch every gated su to grant app root; back up originals to the sidecar.
 
     ``progress`` (optional) is called with a status string for each step.
@@ -434,8 +433,8 @@ def enable(vhd_path: str, progress=None) -> List[str]:
         if progress:
             progress(msg)
 
-    results: List[str] = []
-    merged: Dict[int, str] = {}
+    results: list[str] = []
+    merged: dict[int, str] = {}
     sc = _sidecar(vhd_path)
     if os.path.isfile(sc):
         for p in json.load(open(sc)).get("patches", []):
@@ -485,7 +484,7 @@ def enable(vhd_path: str, progress=None) -> List[str]:
     return results
 
 
-def disable(vhd_path: str, progress=None) -> List[str]:
+def disable(vhd_path: str, progress=None) -> list[str]:
     """Restore original su bytes from the sidecar (un-root)."""
     def _p(msg):
         logger.info(msg)
@@ -496,7 +495,7 @@ def disable(vhd_path: str, progress=None) -> List[str]:
     if not os.path.isfile(sc):
         return ["no backup sidecar -- nothing to restore"]
     patches = json.load(open(sc)).get("patches", [])
-    results: List[str] = []
+    results: list[str] = []
     _p("Opening %s" % os.path.basename(vhd_path))
     vhd = open_disk(vhd_path, writable=True)
     try:
@@ -519,7 +518,7 @@ def disable(vhd_path: str, progress=None) -> List[str]:
     return results
 
 
-def _su_disk(instance_dir: str) -> Optional[str]:
+def _su_disk(instance_dir: str) -> str | None:
     """Disk that holds the live /system/xbin/su on 5.22.150.1014+ -- the writable
     Data.vhdx (bind-mounted rw at /system/xbin). su only appears here after the
     instance's first boot. Falls back to the legacy Root.vhd if Data.vhdx is
@@ -538,7 +537,7 @@ def instance_root_state(instance_dir: str) -> bool:
     return bool(vhd and os.path.isfile(_sidecar(vhd)))
 
 
-def set_instance_root(instance_dir: str, on: bool, progress=None) -> List[str]:
+def set_instance_root(instance_dir: str, on: bool, progress=None) -> list[str]:
     """Root (patch su + back up) or un-root (restore su) a single instance.
 
     The instance must be shut down. Returns human-readable status lines.
@@ -550,8 +549,8 @@ def set_instance_root(instance_dir: str, on: bool, progress=None) -> List[str]:
     return enable(vhd, progress) if on else disable(vhd, progress)
 
 
-def _collect(targets: List[str], all_instances: bool) -> List[str]:
-    vhds: List[str] = []
+def _collect(targets: list[str], all_instances: bool) -> list[str]:
+    vhds: list[str] = []
     if all_instances or not targets:
         if os.path.isdir(ENGINE_DIR):
             for n in sorted(os.listdir(ENGINE_DIR)):
@@ -574,7 +573,7 @@ def _collect(targets: List[str], all_instances: bool) -> List[str]:
     return list(dict.fromkeys(vhds))
 
 
-def run(targets: List[str], action: str, all_instances: bool) -> List[Tuple[str, List[str]]]:
+def run(targets: list[str], action: str, all_instances: bool) -> list[tuple[str, list[str]]]:
     out = []
     for v in _collect(targets, all_instances):
         try:


### PR DESCRIPTION
Closing-up-shop pass ahead of the first tagged release.

**Dead code removed** (each verified 0 references anywhere): `is_toggling` attribute, and unused helpers `is_network_path`, `is_bluestacks_running`, `has_su_symlink`, `_vaddr_to_off`.

**Safe polish** — applied only ruff's behavior-preserving auto-fixes: built-in generics (`List`/`Dict`/`Tuple`/`Optional` → `list`/`dict`/`tuple`/`X | None`), `IOError`→`OSError` (same class), redundant open modes, f-strings, trailing-whitespace/EOL. Added `from __future__ import annotations` everywhere so the modern annotations stay lazy strings — **no minimum-Python bump**. Skipped line-length reflow and any unsafe fixes (churn/risk for no behavior gain).

**Version** bumped to **3.0.0** (`APP_VERSION`), now shown in the window title.

**Release automation** — new `release.yml`: on a `v*` tag push it builds the Windows exe with PyInstaller (bundling favicon + `tools/e2fsprogs`) and publishes a GitHub Release with the exe attached + auto-generated notes.

Net −9 lines. Verified locally: compile, ruff CI gate, all modules import, and the on-device instance-detection + engine-patch-status checks still pass.