### PR TITLE
docs: README updates for v3.0.0 (engine-status, newer-instance listing, releases)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 A utility to toggle root access and read/write (R/W) permissions for BlueStacks 5 instances from a simple graphical interface. It automates the process described in **[Root BlueStacks with Kitsune Mask](https://github.com/RobThePCGuy/Root-Bluestacks-with-Kitsune-Mask/)**.
 
 > [!TIP]
-> **The latest BlueStacks now roots — no downgrade required.** BlueStacks 5.22 added a disk-integrity check that shut rooted instances down with *"Android system doesn't meet security requirements"*. This tool patches that check out, so you can root the current build instead of hunting for an old one. Confirmed working on **5.22.232.1002 / Android 13** (see [Version Compatibility](#version-compatibility)). If you were told to downgrade to 5.21, you no longer have to.
+> **The latest BlueStacks now roots — no downgrade required.** BlueStacks 5.22 added a disk-integrity check that shut rooted instances down with *"Android system doesn't meet security requirements"*. This tool patches that check out, so you can root the current build instead of hunting for an old one. Confirmed working on **5.22.232.1002 / Android 13** — the current latest official BlueStacks build as of July 2026 (see [Version Compatibility](#version-compatibility)). If you were told to downgrade to 5.21, you no longer have to.
 
 ---
 
@@ -22,7 +22,7 @@ A utility to toggle root access and read/write (R/W) permissions for BlueStacks 
 - [Prerequisites](#prerequisites)
 - [Installation](#installation)
 - [Usage Guide](#usage-guide)
-  - [Patch-Mode Builds (5.22.150.1014+)](#patch-mode-builds-52215010141)
+  - [Patch-Mode Builds (5.22.150.1014+)](#patch-mode-builds-5221501014)
   - [Classic Builds (5.22.130 and older / MSI)](#classic-builds-522130-and-older--msi)
   - [Keep Root After Updates](#keep-root-after-updates)
 - [Troubleshooting](#troubleshooting)
@@ -189,6 +189,7 @@ schtasks /Change /TN "BlueStacksHelper_nxt" /DISABLE
 
 </details>
 
+<a id="how-to-downgrade-to-521-legacy"></a>
 <details>
 <summary><b>How to Downgrade to 5.21 (legacy)</b></summary>
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ A utility to toggle root access and read/write (R/W) permissions for BlueStacks 
 ## Features
 
 - **Auto-Detection** - Discovers BlueStacks installation paths via the Windows Registry (Normal, China, and MSI editions) and picks the right rooting method per version automatically
-- **Instance Listing** - Reads `bluestacks.conf` to display all configured instances with live Root and R/W status
-- **Root Toggle** - Enables root the right way for your build: the `enable_root_access` / `bst.feature.rooting` flags on classic builds, plus an offline guest-`su` patch on 5.22.150.1014+
+- **Instance Listing** - Lists every instance with live Root and R/W status, including newer instances that use a single `Data.vhdx` layout (created or cloned) — not just the classic `fastboot.vdi`/`Root.vhd` ones
+- **Engine-Patch Status** - Shows at a glance whether the engine is already patched (*"Engine: Patched ✓"*), so you never have to guess — it's per-install and applies to every instance
+- **Root Toggle** - Enables root the right way for your build: the `enable_root_access` / `bst.feature.rooting` flags on classic builds, plus an offline guest-`su` patch on 5.22.150.1014+. Prompts you to boot a fresh instance once if its `su` isn't generated yet
 - **Engine Patch (5.22+)** - Patches `HD-Player.exe` to disable the *"doesn't meet security"* integrity shutdown, and `HD-MultiInstanceManager.exe` so root isn't reset back off when you edit instances
 - **Read/Write Toggle** - Switches disk files (`fastboot.vdi`, `Root.vhd`) between `Normal` and `Readonly`
 - **Reversible** - Every binary patch backs up to a `.prepatch.bak`; every guest-`su` patch records the original bytes. "Undo Engine Patch" and toggling root off restore the originals
@@ -95,6 +96,9 @@ pyinstaller --onefile --windowed --icon="favicon.ico" --add-data "favicon.ico;."
 
 Output will be in the `dist/` folder.
 
+> [!NOTE]
+> You normally don't need to build by hand — pushing a version tag (`v*`) triggers the `release.yml` workflow, which builds this exact executable on a Windows runner and publishes it to **[Releases](https://github.com/RobThePCGuy/BlueStacks-Root-GUI/releases)** automatically.
+
 ## Usage Guide
 
 Launch the GUI **as administrator**. It auto-detects your BlueStacks installation, lists your instances, and shows the engine-patch buttons only when a patch-mode build (5.22.150.1014+) is present. Follow the section that matches your version.
@@ -109,7 +113,7 @@ This is the path for current BlueStacks. You get root for apps without touching 
 4. **Restart the instance** - start it from BlueStacks. It should boot with **no** security/tamper popup, and root-checker apps (or Kitsune Mask / Magisk) will see root.
 
 > [!TIP]
-> Want Kitsune Mask / Magisk modules too? You can still install them — enable **R/W**, install the APK, and follow the [Kitsune steps](#classic-builds-522130-and-older--msi) below. It's optional on patch-mode builds since apps already have root.
+> This gets **apps** working root — enough for most root-requiring apps and root checkers. If you want **Magisk/Kitsune-managed root with modules and hiding** (Zygisk, Play Integrity Fix, LSPosed, etc.), that's a separate, more involved setup with real emulator gotchas (Zygisk injection, competing-`su` conflicts, modules that hang boot). It's documented in the companion guide: **[Root BlueStacks with Kitsune Mask → Magisk Modules & Hiding](https://github.com/RobThePCGuy/Root-Bluestacks-with-Kitsune-Mask#magisk-modules--hiding-advanced)**.
 
 ### Classic Builds (5.22.130 and older / MSI)
 


### PR DESCRIPTION
Targeted README refresh for the v3.0.0 features (held for your review).

- **Features:** document the new **engine-patch status indicator** (*Engine: Patched ✓*), and that instance listing now covers the **newer single-`Data.vhdx` layout** (created/cloned instances), plus the boot-first prompt on fresh instances.
- **Building:** note that tagged releases are **auto-built and published** by `release.yml` (the Releases link now resolves to a real v3.0.0 exe).
- **Modules tip:** point at the companion Kitsune guide's new **[Magisk Modules & Hiding](https://github.com/RobThePCGuy/Root-Bluestacks-with-Kitsune-Mask#magisk-modules--hiding-advanced)** section instead of the classic steps.

Pairs with the Kitsune-Mask overhaul (that repo's PR #18).