### PR TITLE
Harden engine patch: survive updates, refuse stale/shifted restores

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,10 @@ You should not need this anymore — it's kept for reference only.
 - Check the status bar in the GUI for the error message
 - A full log is written to `%TEMP%\BlueStacksRootGUI.log` — helpful when reporting an issue
 
+**BlueStacks won't launch after patching (locked-down / corporate PCs)**
+- Patching `HD-Player.exe` invalidates its digital signature. Machines that enforce **Windows Defender Application Control (WDAC)** or strict **AppLocker** publisher rules may then block the patched binary from running. This does not affect normal home PCs.
+- If you're on a managed machine and BlueStacks silently fails to start after patching, use **"Undo Engine Patch"** to restore the signed original, or run on a machine without those policies.
+
 ## Development
 
 ### Project Structure

--- a/integrity_patch.py
+++ b/integrity_patch.py
@@ -273,9 +273,27 @@ def patch_file(path: str, specs: list[PatchSpec] = (DISK_INTEGRITY_CALL,),
 
     if make_backup:
         backup = path + BACKUP_SUFFIX
+        # At this point `path` on disk is still the ORIGINAL, unpatched binary
+        # (we only patched the in-memory `data`); so it is safe to back up now.
         if not os.path.exists(backup):
             shutil.copy2(path, backup)
             logger.info("Backed up original to %s", backup)
+        elif _sha256(path) != _sha256(backup):
+            # A backup exists but the current unpatched binary differs from it:
+            # BlueStacks replaced the binary with a newer build since we last
+            # patched. The old backup is stale (a different version), and keeping
+            # it would let a later "Undo" restore the WRONG build over this one.
+            # Archive the stale backup and take a fresh one of the current build.
+            stale = backup + ".old"
+            try:
+                shutil.copy2(backup, stale)
+                logger.info("BlueStacks updated %s since last patch; archived "
+                            "stale backup to %s", os.path.basename(path),
+                            os.path.basename(stale))
+            except OSError:
+                logger.debug("Could not archive stale backup %s", backup, exc_info=True)
+            shutil.copy2(path, backup)
+            logger.info("Refreshed backup for updated %s", os.path.basename(path))
     with open(path, "wb") as fh:
         fh.write(data)
     # Record the hash of the file *as we just patched it*. restore_file() uses

--- a/su_patch_offline.py
+++ b/su_patch_offline.py
@@ -138,6 +138,13 @@ class DynamicVHDX:
         self.f = open(path, "r+b" if writable else "rb")
         if self.f.read(8) != VHDX_SIGNATURE:
             raise ValueError("not a VHDX")
+        # A non-zero LogGuid in the active header means the disk was left dirty
+        # (an unflushed metadata log) by an abrupt shutdown. We read/write the
+        # payload directly and do NOT replay that log, so patching a dirty disk
+        # risks BlueStacks replaying pending entries over our writes on next
+        # boot. Surface it (warn, don't block) so the caller can advise a clean
+        # shutdown first.
+        self.dirty = self._log_dirty()
         # Region table (at 1 MB): find the BAT and Metadata regions.
         self.f.seek(_VHDX_REGION_TABLE_OFF)
         rhdr = self.f.read(16)
@@ -187,6 +194,26 @@ class DynamicVHDX:
                 self._phys_off.append(entry & ~0xFFFFF)
             else:
                 self._phys_off.append(None)
+
+    def _log_dirty(self) -> bool:
+        """True if the VHDX's active header carries a non-zero LogGuid (dirty log).
+
+        The two header sections live at 64 KB and 128 KB; the one with the higher
+        SequenceNumber is active. In each 4 KB header: signature "head" @0,
+        SequenceNumber @8 (u64), LogGuid @48 (16 bytes). All-zero LogGuid = clean.
+        """
+        best_seq = -1
+        dirty = False
+        for hoff in (0x10000, 0x20000):
+            self.f.seek(hoff)
+            hdr = self.f.read(64)
+            if len(hdr) < 64 or hdr[:4] != b"head":
+                continue
+            seq = struct.unpack_from("<Q", hdr, 8)[0]
+            if seq > best_seq:
+                best_seq = seq
+                dirty = hdr[48:64] != b"\x00" * 16
+        return dirty
 
     def is_present(self, blk: int) -> bool:
         return 0 <= blk < self.max_entries and self._phys_off[blk] is not None
@@ -451,6 +478,10 @@ def enable(vhd_path: str, progress=None) -> list[str]:
 
     _p("Opening %s" % os.path.basename(vhd_path))
     vhd = open_disk(vhd_path, writable=True)
+    if getattr(vhd, "dirty", False):
+        _p("WARNING: this instance's disk was not shut down cleanly (dirty VHDX "
+           "log). Boot it once and fully close it before patching, or the patch "
+           "may be lost on next launch.")
     try:
         _p("Scanning /system for su binaries...")
         entries = _scan_su_entries(vhd, _pct)
@@ -498,6 +529,9 @@ def disable(vhd_path: str, progress=None) -> list[str]:
     results: list[str] = []
     _p("Opening %s" % os.path.basename(vhd_path))
     vhd = open_disk(vhd_path, writable=True)
+    if getattr(vhd, "dirty", False):
+        _p("WARNING: this instance's disk was not shut down cleanly (dirty VHDX "
+           "log). Boot it once and fully close it before un-rooting.")
     try:
         for i, p in enumerate(patches, 1):
             _p("Restoring su %d/%d..." % (i, len(patches)))
@@ -506,6 +540,14 @@ def disable(vhd_path: str, progress=None) -> list[str]:
             cur = vhd.read(off, 3)
             if cur == orig:
                 results.append("su@0x%X already original" % off)
+                continue
+            # Only restore when this location still holds OUR patch (b0 01 c3).
+            # If it holds neither the patch nor the original, the ext4 layout has
+            # shifted under us (block reallocated) -- writing the original bytes
+            # blindly could clobber unrelated data, so skip and flag it.
+            if cur != su_patch.PATCH:
+                results.append("su@0x%X unexpected bytes (%s); skipped to avoid "
+                               "clobbering" % (off, cur.hex(" ")))
                 continue
             vhd.write(off, orig)
             results.append("su@0x%X restored (%s -> %s)" % (off, cur.hex(" "), orig.hex(" ")))


### PR DESCRIPTION
Three safety hardenings in the engine-patch / offline-su path. No behavior change on the happy path; each only guards a failure mode.

### 1. Update-lockout: refresh the backup when BlueStacks updates the binary
Before: if BlueStacks replaced a patched `HD-Player.exe` with a newer build and the user re-patched, `patch_file` kept the **old** `.prepatch.bak` but rewrote its `.sha256` to the new build. A later **Undo** then passed the hash guard and restored the *wrong* (older) binary over the current build.

After: on re-patch we compare the current unpatched binary to the existing backup; if they differ, BlueStacks updated it — so we archive the stale backup to `.prepatch.bak.old` and take a fresh backup of the current build. Undo now restores the correct build.

### 2. Warn on a dirty VHDX log
`Data.vhdx` carries a metadata log; a non-zero `LogGuid` in the active header means the instance wasn't shut down cleanly. We write the payload directly and don't replay that log, so a pending entry could drop the patch on next boot. We now detect this and warn (not block) so the user can do a clean shutdown first.

### 3. Don't clobber shifted blocks on un-root
On un-root we now only restore a location that still holds our patch (`b0 01 c3`). If the bytes are neither the patch nor the original (ext4 block reallocated under us), we skip and flag it instead of writing the original bytes into whatever now occupies that offset.

### Testing
Offline unit tests for both the update-lockout scenario (patch v1 → simulated update to v2 → re-patch → Undo restores v2, stale v1 archived) and the dirty-log header detection (active header dirty → warn; stale dirty header ignored). All pass. `py_compile` + `ruff` clean.