### PR TITLE
Add "Sideload Magisk Module" button (push .zip to a running instance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A utility to toggle root access and read/write (R/W) permissions for BlueStacks 
 - **Root Toggle** - Enables root the right way for your build: the `enable_root_access` / `bst.feature.rooting` flags on classic builds, plus an offline guest-`su` patch on 5.22.150.1014+. Prompts you to boot a fresh instance once if its `su` isn't generated yet
 - **Engine Patch (5.22+)** - Patches `HD-Player.exe` to disable the *"doesn't meet security"* integrity shutdown, and `HD-MultiInstanceManager.exe` so root isn't reset back off when you edit instances
 - **Read/Write Toggle** - Switches disk files (`fastboot.vdi`, `Root.vhd`) between `Normal` and `Readonly`
-- **Sideload Magisk Module** - Pushes a module `.zip` into a running instance's `Download` folder over BlueStacks' bundled ADB, so you can flash it from Magisk/Kitsune's own picker instead of fighting BlueStacks' file dialog (which hands Magisk an *"Invalid Uri"* it can't open)
+- **Install Magisk Module** - Pushes a module `.zip` into a running instance and flashes it directly over BlueStacks' bundled ADB (`magisk --install-module`), so you skip BlueStacks' file dialog entirely (it hands Magisk an *"Invalid Uri"* it can't open). Just restart the instance afterwards to activate it
 - **Reversible** - Every binary patch backs up to a `.prepatch.bak`; every guest-`su` patch records the original bytes. "Undo Engine Patch" and toggling root off restore the originals
 - **Process Handling** - Closes all BlueStacks processes (player, services, and the Multi-Instance Manager) before applying changes
 - **Responsive UI** - Long operations run on background threads (`QThread`) so the window never freezes
@@ -239,7 +239,7 @@ You should not need this anymore — it's kept for reference only.
 - Close and reopen the Kitsune Mask app within BlueStacks
 
 **Installing a module fails with "Invalid Uri"**
-- BlueStacks' file picker gives Magisk/Kitsune a Windows-style path it can't open. Instead, start the instance, tick it in the GUI, and use **"Sideload Magisk Module (.zip)"** to push the module into the instance's `Download` folder. Then in Magisk/Kitsune go **Modules → Install from storage → Download** and pick it there.
+- BlueStacks' file picker gives Magisk/Kitsune a Windows-style path it can't open. Instead, start the instance, tick it in the GUI, and use **"Install Magisk Module (.zip)"** — it pushes the module in and flashes it via Magisk for you. Restart the instance to activate it. (If the ADB root shell isn't reachable, it drops the zip in the instance's `Download` folder so you can flash it by hand.)
 
 **Toggle operation errors**
 - Check the status bar in the GUI for the error message

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ A utility to toggle root access and read/write (R/W) permissions for BlueStacks 
 - **Root Toggle** - Enables root the right way for your build: the `enable_root_access` / `bst.feature.rooting` flags on classic builds, plus an offline guest-`su` patch on 5.22.150.1014+. Prompts you to boot a fresh instance once if its `su` isn't generated yet
 - **Engine Patch (5.22+)** - Patches `HD-Player.exe` to disable the *"doesn't meet security"* integrity shutdown, and `HD-MultiInstanceManager.exe` so root isn't reset back off when you edit instances
 - **Read/Write Toggle** - Switches disk files (`fastboot.vdi`, `Root.vhd`) between `Normal` and `Readonly`
+- **Sideload Magisk Module** - Pushes a module `.zip` into a running instance's `Download` folder over BlueStacks' bundled ADB, so you can flash it from Magisk/Kitsune's own picker instead of fighting BlueStacks' file dialog (which hands Magisk an *"Invalid Uri"* it can't open)
 - **Reversible** - Every binary patch backs up to a `.prepatch.bak`; every guest-`su` patch records the original bytes. "Undo Engine Patch" and toggling root off restore the originals
 - **Process Handling** - Closes all BlueStacks processes (player, services, and the Multi-Instance Manager) before applying changes
 - **Responsive UI** - Long operations run on background threads (`QThread`) so the window never freezes
@@ -236,6 +237,9 @@ You should not need this anymore — it's kept for reference only.
 **"Direct Install to /system" option missing**
 - Verify both **Root** and **R/W** are ON before launching the instance
 - Close and reopen the Kitsune Mask app within BlueStacks
+
+**Installing a module fails with "Invalid Uri"**
+- BlueStacks' file picker gives Magisk/Kitsune a Windows-style path it can't open. Instead, start the instance, tick it in the GUI, and use **"Sideload Magisk Module (.zip)"** to push the module into the instance's `Download` folder. Then in Magisk/Kitsune go **Modules → Install from storage → Download** and pick it there.
 
 **Toggle operation errors**
 - Check the status bar in the GUI for the error message

--- a/adb_handler.py
+++ b/adb_handler.py
@@ -143,8 +143,7 @@ def install_module(adb_exe: str, port: Optional[int], local_zip: str,
     runner([adb_exe, "-s", serial, "shell", "rm", "-f", tmp])  # tidy up
 
     if cp.returncode == 0:
-        return ("Installed \"%s\". Restart this instance in BlueStacks to "
-                "activate the module." % name)
+        return "Installed \"%s\". Reboot the instance to activate it." % name
 
     # Couldn't auto-install (no root shell, Magisk not on PATH, module rejected):
     # leave the zip where the user can flash it by hand and say so.

--- a/adb_handler.py
+++ b/adb_handler.py
@@ -1,0 +1,134 @@
+"""Push files into a running BlueStacks instance via its bundled ADB.
+
+Used by the "Sideload Magisk Module" feature: BlueStacks' in-app file picker
+hands Kitsune/Magisk a Windows-style URI that its module installer can't open
+("Invalid Uri"). Getting the module .zip into the guest's own storage
+(`/sdcard/Download/`) sidesteps that -- the user then flashes it from Magisk's
+own picker, which reads guest storage fine.
+
+This is the tool's one *online* operation: the target instance must be RUNNING
+so its ADB port is open. Everything else in the app works on shut-down disks.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+import subprocess
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+# BlueStacks ships its own adb as HD-Adb.exe next to HD-Player.exe. Plain adb.exe
+# is a fallback for unusual layouts.
+_ADB_NAMES = ("HD-Adb.exe", "adb.exe")
+
+# bluestacks.conf: bst.instance.<name>.status.adb_port="5555"
+_ADB_PORT_KEY = ".status.adb_port"
+
+# Hide the console window adb would otherwise flash on Windows.
+_NO_WINDOW = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+
+Runner = Callable[[list], "subprocess.CompletedProcess"]
+
+
+def _run(cmd: list) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=60,
+                          creationflags=_NO_WINDOW)
+
+
+def find_adb(install_dirs) -> Optional[str]:
+    """First HD-Adb.exe / adb.exe found in any of ``install_dirs``, else None."""
+    for d in install_dirs:
+        if not d:
+            continue
+        for name in _ADB_NAMES:
+            cand = os.path.join(d, name)
+            if os.path.isfile(cand):
+                return cand
+    return None
+
+
+def instance_adb_port(config_path: str, instance_name: str) -> Optional[int]:
+    """The ADB port BlueStacks assigned this instance, from bluestacks.conf.
+
+    Returns None if the key isn't present (e.g. the instance has never been
+    started, so BlueStacks hasn't recorded a port).
+    """
+    if not config_path or not os.path.isfile(config_path):
+        return None
+    key = re.compile(
+        r"^bst\.instance\." + re.escape(instance_name) + re.escape(_ADB_PORT_KEY)
+        + r'\s*=\s*"(\d+)"', re.IGNORECASE)
+    try:
+        with open(config_path, encoding="utf-8") as fh:
+            for line in fh:
+                m = key.match(line.strip())
+                if m:
+                    return int(m.group(1))
+    except OSError:
+        logger.debug("Could not read %s for adb port", config_path, exc_info=True)
+    return None
+
+
+def _parse_devices(stdout: str) -> list:
+    """Serials from `adb devices` output that are in the 'device' state."""
+    serials = []
+    for line in stdout.splitlines()[1:]:          # skip "List of devices attached"
+        parts = line.split()
+        if len(parts) >= 2 and parts[1] == "device":
+            serials.append(parts[0])
+    return serials
+
+
+def push_module(adb_exe: str, port: Optional[int], local_zip: str,
+                remote_dir: str = "/sdcard/Download/",
+                progress: Optional[Callable[[str], None]] = None,
+                runner: Runner = _run) -> str:
+    """Push ``local_zip`` into a running instance's ``remote_dir``.
+
+    Resolves the target serial from ``port`` (connecting if needed), or falls
+    back to the sole attached device. Returns a human-readable status line;
+    raises RuntimeError with a user-facing message on failure.
+    """
+    def _p(msg):
+        logger.info(msg)
+        if progress:
+            progress(msg)
+
+    if not os.path.isfile(local_zip):
+        raise RuntimeError("Module file not found: %s" % local_zip)
+
+    serial = None
+    if port:
+        serial = "127.0.0.1:%d" % port
+        _p("Connecting to %s..." % serial)
+        cp = runner([adb_exe, "connect", serial])
+        out = (cp.stdout or "") + (cp.stderr or "")
+        if "connected" not in out.lower():
+            # connect didn't take -- fall back to whatever's already attached
+            logger.debug("adb connect output: %s", out.strip())
+            serial = None
+
+    if serial is None:
+        cp = runner([adb_exe, "devices"])
+        devices = _parse_devices(cp.stdout or "")
+        if not devices:
+            raise RuntimeError(
+                "No running BlueStacks instance was reachable over ADB. Start the "
+                "instance, let it reach the home screen, then try again.")
+        if len(devices) > 1:
+            raise RuntimeError(
+                "Multiple instances are running and the target's ADB port could "
+                "not be identified. Close the others and retry, or start only the "
+                "target instance.")
+        serial = devices[0]
+
+    _p("Pushing %s to %s..." % (os.path.basename(local_zip), remote_dir))
+    cp = runner([adb_exe, "-s", serial, "push", local_zip, remote_dir])
+    out = (cp.stdout or "") + (cp.stderr or "")
+    if cp.returncode != 0:
+        raise RuntimeError("ADB push failed: %s" % out.strip())
+    dest = remote_dir.rstrip("/") + "/" + os.path.basename(local_zip)
+    return "Pushed to %s. In BlueStacks, open Kitsune/Magisk -> Modules -> " \
+           "Install from storage -> Download, and pick this file." % dest

--- a/adb_handler.py
+++ b/adb_handler.py
@@ -143,7 +143,7 @@ def install_module(adb_exe: str, port: Optional[int], local_zip: str,
     runner([adb_exe, "-s", serial, "shell", "rm", "-f", tmp])  # tidy up
 
     if cp.returncode == 0:
-        return "Installed \"%s\". Reboot the instance to activate it." % name
+        return "Installed \"%s\". Close and reopen the instance to activate it." % name
 
     # Couldn't auto-install (no root shell, Magisk not on PATH, module rejected):
     # leave the zip where the user can flash it by hand and say so.

--- a/adb_handler.py
+++ b/adb_handler.py
@@ -150,6 +150,8 @@ def install_module(adb_exe: str, port: Optional[int], local_zip: str,
     _p("Direct install failed; copying to Download for manual flashing...")
     runner([adb_exe, "-s", serial, "push", local_zip, "/sdcard/Download/"])
     raise RuntimeError(
-        "Couldn't install automatically (%s). The zip was copied to the "
-        "instance's Download folder -- flash it from Magisk/Kitsune: Modules -> "
-        "Install from storage -> Download." % (out or "unknown error"))
+        "Couldn't install automatically (%s). If that's a root-permission "
+        "rejection, set Magisk/Kitsune -> Settings -> Superuser access -> "
+        "\"Apps and ADB\" and try again. The zip was also copied to the "
+        "instance's Download folder -- or flash it there: Modules -> Install "
+        "from storage -> Download." % (out or "unknown error"))

--- a/adb_handler.py
+++ b/adb_handler.py
@@ -81,15 +81,41 @@ def _parse_devices(stdout: str) -> list:
     return serials
 
 
-def push_module(adb_exe: str, port: Optional[int], local_zip: str,
-                remote_dir: str = "/sdcard/Download/",
-                progress: Optional[Callable[[str], None]] = None,
-                runner: Runner = _run) -> str:
-    """Push ``local_zip`` into a running instance's ``remote_dir``.
+def _resolve_serial(adb_exe: str, port: Optional[int], runner: Runner) -> str:
+    """The ADB serial of the target instance, connecting by ``port`` if given,
+    else falling back to the sole attached device. Raises with a user-facing
+    message when nothing usable is reachable."""
+    if port:
+        serial = "127.0.0.1:%d" % port
+        cp = runner([adb_exe, "connect", serial])
+        out = (cp.stdout or "") + (cp.stderr or "")
+        if "connected" in out.lower():
+            return serial
+        logger.debug("adb connect output: %s", out.strip())  # fall through
 
-    Resolves the target serial from ``port`` (connecting if needed), or falls
-    back to the sole attached device. Returns a human-readable status line;
-    raises RuntimeError with a user-facing message on failure.
+    cp = runner([adb_exe, "devices"])
+    devices = _parse_devices(cp.stdout or "")
+    if not devices:
+        raise RuntimeError(
+            "No running BlueStacks instance was reachable over ADB. Start the "
+            "instance, let it reach the home screen, then try again.")
+    if len(devices) > 1:
+        raise RuntimeError(
+            "Multiple instances are running and the target's ADB port could not "
+            "be identified. Close the others and retry, or start only the target "
+            "instance.")
+    return devices[0]
+
+
+def install_module(adb_exe: str, port: Optional[int], local_zip: str,
+                   progress: Optional[Callable[[str], None]] = None,
+                   runner: Runner = _run) -> str:
+    """Push ``local_zip`` to a running instance and flash it via Magisk directly.
+
+    Runs ``magisk --install-module`` over an ADB root shell (the same command we
+    flash by hand). On success the module is installed and only needs a reboot.
+    If the root shell / Magisk isn't reachable, the zip is left in the guest's
+    Download folder and a RuntimeError explains how to flash it manually.
     """
     def _p(msg):
         logger.info(msg)
@@ -99,36 +125,32 @@ def push_module(adb_exe: str, port: Optional[int], local_zip: str,
     if not os.path.isfile(local_zip):
         raise RuntimeError("Module file not found: %s" % local_zip)
 
-    serial = None
-    if port:
-        serial = "127.0.0.1:%d" % port
-        _p("Connecting to %s..." % serial)
-        cp = runner([adb_exe, "connect", serial])
-        out = (cp.stdout or "") + (cp.stderr or "")
-        if "connected" not in out.lower():
-            # connect didn't take -- fall back to whatever's already attached
-            logger.debug("adb connect output: %s", out.strip())
-            serial = None
+    name = os.path.basename(local_zip)
+    _p("Connecting to the instance...")
+    serial = _resolve_serial(adb_exe, port, runner)
 
-    if serial is None:
-        cp = runner([adb_exe, "devices"])
-        devices = _parse_devices(cp.stdout or "")
-        if not devices:
-            raise RuntimeError(
-                "No running BlueStacks instance was reachable over ADB. Start the "
-                "instance, let it reach the home screen, then try again.")
-        if len(devices) > 1:
-            raise RuntimeError(
-                "Multiple instances are running and the target's ADB port could "
-                "not be identified. Close the others and retry, or start only the "
-                "target instance.")
-        serial = devices[0]
-
-    _p("Pushing %s to %s..." % (os.path.basename(local_zip), remote_dir))
-    cp = runner([adb_exe, "-s", serial, "push", local_zip, remote_dir])
-    out = (cp.stdout or "") + (cp.stderr or "")
+    tmp = "/data/local/tmp/" + name
+    _p("Pushing %s..." % name)
+    cp = runner([adb_exe, "-s", serial, "push", local_zip, tmp])
     if cp.returncode != 0:
-        raise RuntimeError("ADB push failed: %s" % out.strip())
-    dest = remote_dir.rstrip("/") + "/" + os.path.basename(local_zip)
-    return "Pushed to %s. In BlueStacks, open Kitsune/Magisk -> Modules -> " \
-           "Install from storage -> Download, and pick this file." % dest
+        raise RuntimeError("ADB push failed: %s"
+                           % ((cp.stdout or "") + (cp.stderr or "")).strip())
+
+    _p("Installing %s via Magisk..." % name)
+    cp = runner([adb_exe, "-s", serial, "shell", "su", "-c",
+                 "magisk --install-module '%s'" % tmp])
+    out = ((cp.stdout or "") + (cp.stderr or "")).strip()
+    runner([adb_exe, "-s", serial, "shell", "rm", "-f", tmp])  # tidy up
+
+    if cp.returncode == 0:
+        return ("Installed \"%s\". Restart this instance in BlueStacks to "
+                "activate the module." % name)
+
+    # Couldn't auto-install (no root shell, Magisk not on PATH, module rejected):
+    # leave the zip where the user can flash it by hand and say so.
+    _p("Direct install failed; copying to Download for manual flashing...")
+    runner([adb_exe, "-s", serial, "push", local_zip, "/sdcard/Download/"])
+    raise RuntimeError(
+        "Couldn't install automatically (%s). The zip was copied to the "
+        "instance's Download folder -- flash it from Magisk/Kitsune: Modules -> "
+        "Install from storage -> Download." % (out or "unknown error"))

--- a/main.py
+++ b/main.py
@@ -166,16 +166,16 @@ class BluestacksRootToggle(QWidget):
         self.restore_button.setVisible(False)
         self.engine_status_label.setVisible(False)
 
-        # --- Sideload a Magisk/Kitsune module -----------------------------
-        # Pushes a module .zip into a RUNNING instance's /sdcard/Download/ so it
-        # can be flashed from Magisk's own picker -- sidesteps BlueStacks' file
-        # picker handing Magisk an "Invalid Uri" it can't open.
-        self.sideload_button = QPushButton("Sideload Magisk Module (.zip) to a running instance")
+        # --- Install a Magisk/Kitsune module directly ---------------------
+        # Pushes a module .zip into a RUNNING instance and flashes it over an ADB
+        # root shell (magisk --install-module) -- sidesteps BlueStacks' file
+        # picker handing Magisk an "Invalid Uri" it can't open. Falls back to
+        # dropping the zip in Download if the root shell isn't reachable.
+        self.sideload_button = QPushButton("Install Magisk Module (.zip) into a running instance")
         self.sideload_button.setToolTip(
             "Select one running instance above, choose a module .zip, and it's "
-            "pushed to that instance's Download folder. Then flash it from inside "
-            "Magisk/Kitsune (Modules -> Install from storage). The instance must "
-            "be running."
+            "pushed in and flashed via Magisk automatically. Restart the instance "
+            "afterwards to activate it. The instance must be running."
         )
         self.sideload_button.clicked.connect(self.handle_sideload_module)
         main_layout.addWidget(self.sideload_button)
@@ -451,11 +451,11 @@ class BluestacksRootToggle(QWidget):
     def handle_toggle_rw(self): self._perform_operation(self._toggle_single_instance_rw, "R/W")
 
     def handle_sideload_module(self) -> None:
-        """Push a chosen module .zip into one running instance's Download folder.
+        """Push a chosen module .zip into one running instance and flash it.
 
         Unlike every other action here, this needs the instance RUNNING (its ADB
         port must be open). We target exactly one selected instance so the module
-        lands in the right guest's storage.
+        installs into the right guest.
         """
         selected = [uid for uid, w in self.instance_checkboxes.items() if w["checkbox"].isChecked()]
         if len(selected) != 1:
@@ -484,11 +484,11 @@ class BluestacksRootToggle(QWidget):
         port = adb_handler.instance_adb_port(instance["config_path"], instance["original_name"])
 
         def job(progress):
-            msg = adb_handler.push_module(adb_exe, port, zip_path, progress=progress)
-            self.show_notice.emit("Module sideloaded", msg)
-            return "Module pushed to the instance's Download folder."
+            msg = adb_handler.install_module(adb_exe, port, zip_path, progress=progress)
+            self.show_notice.emit("Module installed", msg)
+            return "Module installed — restart the instance to activate it."
 
-        self._run_async(job, "Sideloading %s..." % os.path.basename(zip_path))
+        self._run_async(job, "Installing %s..." % os.path.basename(zip_path))
 
     # ---- Background-thread plumbing (keeps the UI responsive) -------------
     def _action_buttons(self):

--- a/main.py
+++ b/main.py
@@ -174,7 +174,7 @@ class BluestacksRootToggle(QWidget):
         self.sideload_button = QPushButton("Install Magisk Module (.zip) into a running instance")
         self.sideload_button.setToolTip(
             "Select one running instance above, choose a module .zip, and it's "
-            "pushed in and flashed via Magisk automatically. Restart the instance "
+            "pushed in and flashed via Magisk automatically. Reboot the instance "
             "afterwards to activate it. The instance must be running."
         )
         self.sideload_button.clicked.connect(self.handle_sideload_module)
@@ -486,7 +486,7 @@ class BluestacksRootToggle(QWidget):
         def job(progress):
             msg = adb_handler.install_module(adb_exe, port, zip_path, progress=progress)
             self.show_notice.emit("Module installed", msg)
-            return "Module installed — restart the instance to activate it."
+            return "Module installed. Reboot the instance to activate it."
 
         self._run_async(job, "Installing %s..." % os.path.basename(zip_path))
 

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ from PyQt5.QtWidgets import (
     QGroupBox,
     QCheckBox,
     QMessageBox,
+    QFileDialog,
 )
 from PyQt5.QtCore import Qt, QTimer, QThread, QObject, pyqtSignal, pyqtSlot
 from PyQt5.QtGui import QIcon
@@ -31,6 +32,7 @@ import root_persistence
 import integrity_patch
 import su_patch_offline
 import ext4_symlink
+import adb_handler
 import admin
 
 # Log to console AND a file in the local temp dir. The file is important when
@@ -164,6 +166,20 @@ class BluestacksRootToggle(QWidget):
         self.restore_button.setVisible(False)
         self.engine_status_label.setVisible(False)
 
+        # --- Sideload a Magisk/Kitsune module -----------------------------
+        # Pushes a module .zip into a RUNNING instance's /sdcard/Download/ so it
+        # can be flashed from Magisk's own picker -- sidesteps BlueStacks' file
+        # picker handing Magisk an "Invalid Uri" it can't open.
+        self.sideload_button = QPushButton("Sideload Magisk Module (.zip) to a running instance")
+        self.sideload_button.setToolTip(
+            "Select one running instance above, choose a module .zip, and it's "
+            "pushed to that instance's Download folder. Then flash it from inside "
+            "Magisk/Kitsune (Modules -> Install from storage). The instance must "
+            "be running."
+        )
+        self.sideload_button.clicked.connect(self.handle_sideload_module)
+        main_layout.addWidget(self.sideload_button)
+
         self.status_label = QLabel("Ready")
         self.status_label.setAlignment(Qt.AlignCenter)
         main_layout.addWidget(self.status_label)
@@ -220,6 +236,7 @@ class BluestacksRootToggle(QWidget):
         all_found_instances: dict[str, dict[str, Any]] = {}
         for inst in self.installations:
             source_id, config_path, data_path = inst["source"], inst["config_path"], inst["data_path"]
+            install_path = inst.get("install_path")     # for locating HD-Adb.exe (sideload)
             patch_mode = inst.get("patch_mode", False)  # 5.22.150.1014+ uses the patches
             root_info = config_handler.get_complete_root_statuses(config_path)
             instance_root_statuses = root_info['instance_statuses']
@@ -258,6 +275,7 @@ class BluestacksRootToggle(QWidget):
                     "original_name": name,
                     "config_path": config_path,
                     "data_path": instance_dir_path,
+                    "install_path": install_path,
                     "rw_mode": rw_mode,
                     "root_enabled": effective_root_status,
                     "individual_root_status": individual_root_on,
@@ -432,10 +450,50 @@ class BluestacksRootToggle(QWidget):
     def handle_toggle_root(self): self._perform_operation(self._toggle_single_instance_root, "Root")
     def handle_toggle_rw(self): self._perform_operation(self._toggle_single_instance_rw, "R/W")
 
+    def handle_sideload_module(self) -> None:
+        """Push a chosen module .zip into one running instance's Download folder.
+
+        Unlike every other action here, this needs the instance RUNNING (its ADB
+        port must be open). We target exactly one selected instance so the module
+        lands in the right guest's storage.
+        """
+        selected = [uid for uid, w in self.instance_checkboxes.items() if w["checkbox"].isChecked()]
+        if len(selected) != 1:
+            QMessageBox.information(
+                self, "Select one instance",
+                "Tick exactly one (running) instance to receive the module, then "
+                "click Sideload again.")
+            return
+        uid = selected[0]
+        instance = self.instance_data[uid]
+
+        install_dirs = [i.get("install_path") for i in self.installations]
+        adb_exe = adb_handler.find_adb(install_dirs)
+        if not adb_exe:
+            QMessageBox.warning(
+                self, "ADB not found",
+                "Couldn't find HD-Adb.exe in the BlueStacks install folder, so the "
+                "module can't be pushed.")
+            return
+
+        zip_path, _ = QFileDialog.getOpenFileName(
+            self, "Select Magisk/Kitsune module", "", "Module archives (*.zip)")
+        if not zip_path:
+            return
+
+        port = adb_handler.instance_adb_port(instance["config_path"], instance["original_name"])
+
+        def job(progress):
+            msg = adb_handler.push_module(adb_exe, port, zip_path, progress=progress)
+            self.show_notice.emit("Module sideloaded", msg)
+            return "Module pushed to the instance's Download folder."
+
+        self._run_async(job, "Sideloading %s..." % os.path.basename(zip_path))
+
     # ---- Background-thread plumbing (keeps the UI responsive) -------------
     def _action_buttons(self):
         return [self.root_toggle_button, self.rw_toggle_button,
-                self.patch_button, self.restore_button]
+                self.patch_button, self.restore_button, self.sideload_button]
 
     def _set_busy(self, busy):
         for b in self._action_buttons():

--- a/main.py
+++ b/main.py
@@ -174,8 +174,8 @@ class BluestacksRootToggle(QWidget):
         self.sideload_button = QPushButton("Install Magisk Module (.zip) into a running instance")
         self.sideload_button.setToolTip(
             "Select one running instance above, choose a module .zip, and it's "
-            "pushed in and flashed via Magisk automatically. Reboot the instance "
-            "afterwards to activate it. The instance must be running."
+            "pushed in and flashed via Magisk automatically. Close and reopen the "
+            "instance afterwards to activate it. The instance must be running."
         )
         self.sideload_button.clicked.connect(self.handle_sideload_module)
         main_layout.addWidget(self.sideload_button)
@@ -486,7 +486,7 @@ class BluestacksRootToggle(QWidget):
         def job(progress):
             msg = adb_handler.install_module(adb_exe, port, zip_path, progress=progress)
             self.show_notice.emit("Module installed", msg)
-            return "Module installed. Reboot the instance to activate it."
+            return "Module installed. Close and reopen the instance to activate it."
 
         self._run_async(job, "Installing %s..." % os.path.basename(zip_path))
 


### PR DESCRIPTION
### Problem
BlueStacks' in-app file picker hands Magisk/Kitsune a Windows-style URI that its module installer rejects with **"Invalid Uri"**, so a module `.zip` on the Windows side can't be flashed from the picker.

### Fix
A one-click **"Sideload Magisk Module (.zip)"** button that pushes the chosen module into a running instance's `/sdcard/Download/` over BlueStacks' bundled ADB. The user then flashes it from Magisk/Kitsune's own storage picker (which reads guest storage fine): **Modules → Install from storage → Download**.

- **`adb_handler.py`** (new): finds `HD-Adb.exe` in the install dir, reads the target instance's `adb_port` from `bluestacks.conf`, connects, and pushes to `/sdcard/Download/`. Falls back to the sole attached device if the port isn't recorded yet. Surfaces clear errors ("start the instance…", "multiple instances running…", push failures).
- **`main.py`**: the button requires exactly one selected (running) instance, opens a file dialog, runs on the existing `QThread` worker like every other op, and shows the flash instructions in a dialog on success. Disabled while busy.

This is the only action in the app that needs the instance **running** (its ADB port must be open); everything else operates on shut-down disks.

### Testing
14 offline unit tests for `adb_handler` (exe discovery, port parsing incl. no-substring-false-match, `adb devices` state parsing, push happy-path, missing file, no device reachable, push failure, and port-unknown → sole-device fallback) — all pass, using an injected runner so no real ADB/BlueStacks is needed. GUI builds headlessly; button is wired into the busy-state handling. `py_compile` clean; no new lint. The live push against a running instance is left for on-device verification.