### PR TITLE
Fix su-locator missing rdx/rbx/rbp lea register variants

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -70,6 +70,15 @@ REGEX_BSTK_READONLY_PATTERN = re.compile(
 )
 
 
+# modrm bytes for a RIP-relative `lea rXX, [rip+rel32]` (48/4C 8D <modrm> rel32),
+# one entry per general-purpose destination register (mod=00, rm=101, reg=0..7).
+# Shared by su_patch.py and integrity_patch.py so their two `lea`-scanners can't
+# drift into recognizing different register subsets (see issue #49: su_patch's
+# locator only accepted rax/rcx/rsi/rdi, silently missing an su binary whose
+# isDeveloperMode() lea happened to target rdx/rbx/rbp).
+RIP_LEA_MODRM = frozenset({0x05, 0x0D, 0x15, 0x1D, 0x25, 0x2D, 0x35, 0x3D})
+
+
 BLUESTACKS_PROCESS_NAMES = [
     "HD-Player.exe",
     # Must be terminated before patching: the engine patch rewrites

--- a/integrity_patch.py
+++ b/integrity_patch.py
@@ -49,6 +49,8 @@ import sys
 from dataclasses import dataclass
 from typing import Callable
 
+import constants
+
 logger = logging.getLogger(__name__)
 
 # Backup suffix appended next to the original executable before patching.
@@ -190,14 +192,12 @@ def _locate_isdiskverify(data: bytes) -> list[int]:
         return []
     str_va = image_base + str_rva
 
-    # rip-relative lea modrm bytes (reg in bits 3-5, mod=00 rm=101)
-    rip_modrm = {0x05, 0x0D, 0x15, 0x1D, 0x25, 0x2D, 0x35, 0x3D}
     i = 0
     while True:
         i = data.find(b"\x8D", i)
         if i < 0 or i + 5 > len(data):
             break
-        if i >= 1 and data[i - 1] in (0x48, 0x4C) and data[i + 1] in rip_modrm:
+        if i >= 1 and data[i - 1] in (0x48, 0x4C) and data[i + 1] in constants.RIP_LEA_MODRM:
             lea_off = i - 1
             lea_rva = file_offset_to_rva(sections, lea_off)
             if lea_rva is not None:

--- a/su_patch.py
+++ b/su_patch.py
@@ -40,6 +40,8 @@ import shutil
 import struct
 import sys
 
+import constants
+
 logger = logging.getLogger(__name__)
 
 DEVMODE_STRING = b"isDeveloperMode: Function started.\x00"
@@ -108,7 +110,7 @@ def _find_isdevmode_entry(data: bytes) -> int | None:
             i = data.find(b"\x8d", i)
             if i < 0 or i + 5 > len(data):
                 break
-            if i >= 1 and data[i - 1] in (0x48, 0x4C) and data[i + 1] in (0x05, 0x0D, 0x3D, 0x35):
+            if i >= 1 and data[i - 1] in (0x48, 0x4C) and data[i + 1] in constants.RIP_LEA_MODRM:
                 rel = struct.unpack_from("<i", data, i + 2)[0]
                 lea_off = i - 1
                 lea_vaddr = _off_to_vaddr(segs, lea_off)

--- a/tests/test_su_patch_locator.py
+++ b/tests/test_su_patch_locator.py
@@ -1,0 +1,49 @@
+"""Regression coverage for issue #49: `_find_isdevmode_entry` missed valid
+`lea rXX, [rip+rel32]` register variants (rdx/rbx/rbp), silently skipping su
+binaries that used them. Repro courtesy of @guclumhg's issue report."""
+import struct
+
+import pytest
+
+import su_patch
+
+# reg -> modrm byte for `lea rXX, [rip+rel32]` (mod=00, rm=101)
+_REGS = {
+    "rax": 0x05, "rcx": 0x0D, "rdx": 0x15, "rbx": 0x1D,
+    "rbp": 0x2D, "rsi": 0x35, "rdi": 0x3D,
+}
+
+
+def _build_elf64(modrm: int) -> bytes:
+    """Minimal ELF64, one PT_LOAD segment containing `push rbx; lea rXX,[rip+rel]`
+    immediately followed by DEVMODE_STRING, so the lea's rip-relative target
+    resolves to the string's own vaddr."""
+    devstr = su_patch.DEVMODE_STRING
+    vbase, phoff, f, s = 0x400000, 0x40, 0x80, 0x100
+    total = s + len(devstr)
+    b = bytearray(total)
+    b[0:4] = b"\x7fELF"
+    b[4] = 2  # ELFCLASS64
+    b[5] = 1  # little-endian
+    b[6] = 1  # EI_VERSION
+    struct.pack_into("<H", b, 0x10, 2)      # e_type = ET_EXEC
+    struct.pack_into("<H", b, 0x12, 0x3E)   # e_machine = EM_X86_64
+    struct.pack_into("<Q", b, 0x20, phoff)  # e_phoff
+    struct.pack_into("<H", b, 0x36, 56)     # e_phentsize
+    struct.pack_into("<H", b, 0x38, 1)      # e_phnum
+    struct.pack_into("<I", b, phoff + 0, 1)        # PT_LOAD
+    struct.pack_into("<Q", b, phoff + 8, 0)        # p_offset
+    struct.pack_into("<Q", b, phoff + 16, vbase)   # p_vaddr
+    struct.pack_into("<Q", b, phoff + 32, total)   # p_filesz
+    b[f], b[f + 1], b[f + 2], b[f + 3] = 0x53, 0x48, 0x8D, modrm  # push rbx; lea reg,[rip+rel]
+    rel = (vbase + s) - (vbase + (f + 1) + 7)
+    struct.pack_into("<i", b, f + 4, rel)
+    b[s:s + len(devstr)] = devstr
+    return bytes(b)
+
+
+@pytest.mark.parametrize("reg", sorted(_REGS))
+def test_find_isdevmode_entry_accepts_every_gp_register(reg):
+    modrm = _REGS[reg]
+    entry = su_patch._find_isdevmode_entry(_build_elf64(modrm))
+    assert entry is not None, f"lea targeting {reg} (modrm=0x{modrm:02X}) was not found"


### PR DESCRIPTION
## What & why

Fixes #49. `_find_isdevmode_entry()` in `su_patch.py` — the unpatched-`su` locator that `enable()` relies on — only recognized a RIP-relative `lea rXX, [rip+rel32]` into `rax/rcx/rsi/rdi`. `integrity_patch.py`'s own `lea`-scanner already accepted all 8 general-purpose registers, so the two locators disagreed on what counts as a valid entry for the identical instruction shape.

Practical effect: an `su` binary whose `isDeveloperMode()` entry happens to load the string into `rdx`, `rbx`, or `rbp` gets silently skipped by the GUI path (`enable()` → `_scan_su_entries` → `_classify_elf_su` → `_find_isdevmode_entry`) — no `su` patched, no error, just "no gated su found."

All credit to @guclumhg for the report — the root-cause analysis, the register-set comparison table, and the synthetic-ELF repro are theirs (from #49); this PR is their proposed fix applied plus a regression test.

## Fix

- `constants.py`: new `RIP_LEA_MODRM` — the 8-entry modrm set, shared.
- `su_patch.py`: `_find_isdevmode_entry` now uses `constants.RIP_LEA_MODRM` instead of its own 4-entry tuple.
- `integrity_patch.py`: its locator now imports the same constant instead of defining its own local copy (verified byte-identical to the set it replaces — no behavior change there).
- `su_patch_offline.py`'s `_classify_elf_su` (the *patched*-su recognizer) already accepted all 8 registers via a bitmask test; untouched.

## Testing

- New `tests/test_su_patch_locator.py`, parametrized over all 7 reachable GP registers, built from the issue's synthetic-ELF repro.
- Confirmed the new test fails on `rdx`/`rbx`/`rbp` against pre-fix code (exactly the 3 the issue named) and passes for all 7 post-fix.
- Full suite: 82 passed (75 pre-existing + 7 new).
- `ruff check --select E9,F63,F7,F82,F401 .` and `python -m compileall -q .` both clean (same gates CI runs).
- Confirmed `integrity_patch.RIP_LEA_MODRM` usage is byte-identical to the literal set it replaced, so that locator's behavior is unchanged.

Scope note (per the issue): 32-bit path is untouched, it's `eax`-only in both files and internally consistent already.
