### PR TITLE
Port instance display names + root-color highlighting onto nav-rail UI

### DIFF
--- a/config_handler.py
+++ b/config_handler.py
@@ -91,16 +91,19 @@ def get_complete_root_statuses(config_path: str) -> dict[str, Any]:
         config_path: Path to the bluestacks.conf file.
 
     Returns:
-        A dictionary like: {'global_status': bool, 'instance_statuses': {name: bool}}
+        A dictionary like:
+        {'global_status': bool, 'instance_statuses': {name: bool}, 'display_names': {name: str}}
     """
     instance_statuses: dict[str, bool] = {}
+    display_names: dict[str, str] = {}
     global_status: bool = False
+    empty_result = {"global_status": False, "instance_statuses": {}, "display_names": {}}
 
     if not os.path.isfile(config_path):
         logger.warning(
             f"Config file not found for reading root statuses: {config_path}"
         )
-        return {"global_status": False, "instance_statuses": {}}
+        return empty_result
 
     # FIX: Regex for both instance-specific and global root keys
     instance_pattern = re.compile(
@@ -108,6 +111,14 @@ def get_complete_root_statuses(config_path: str) -> dict[str, Any]:
         + re.escape(constants.INSTANCE_PREFIX)
         + r"([^.]+)"
         + re.escape(constants.ENABLE_ROOT_KEY)
+        + r'\s*=\s*"([^"]*)"',
+        re.IGNORECASE,
+    )
+    display_name_pattern = re.compile(
+        r"^"
+        + re.escape(constants.INSTANCE_PREFIX)
+        + r"([^.]+)"
+        + re.escape(constants.DISPLAY_NAME_KEY)
         + r'\s*=\s*"([^"]*)"',
         re.IGNORECASE,
     )
@@ -131,8 +142,18 @@ def get_complete_root_statuses(config_path: str) -> dict[str, Any]:
                     instance_name, value = match.group(1), match.group(2)
                     is_enabled = value == "1"
                     instance_statuses[instance_name] = is_enabled
+
+                # Check for instance display-name key
+                name_match = display_name_pattern.match(stripped_line)
+                if name_match:
+                    instance_name, value = name_match.group(1), name_match.group(2)
+                    display_names[instance_name] = value
     except Exception:
         logger.exception(f"Error reading config file {config_path} for root statuses.")
-        return {"global_status": False, "instance_statuses": {}}
+        return empty_result
 
-    return {"global_status": global_status, "instance_statuses": instance_statuses}
+    return {
+        "global_status": global_status,
+        "instance_statuses": instance_statuses,
+        "display_names": display_names,
+    }

--- a/constants.py
+++ b/constants.py
@@ -5,6 +5,7 @@ import re
 
 INSTANCE_PREFIX = "bst.instance."
 ENABLE_ROOT_KEY = ".enable_root_access"
+DISPLAY_NAME_KEY = ".display_name"
 FEATURE_ROOTING_KEY = "bst.feature.rooting"
 BLUESTACKS_CONF_FILENAME = "bluestacks.conf"
 

--- a/tests/test_config_handler.py
+++ b/tests/test_config_handler.py
@@ -1,0 +1,37 @@
+import config_handler
+
+
+def _write_conf(tmp_path, text):
+    conf = tmp_path / "bluestacks.conf"
+    conf.write_text(text, encoding="utf-8")
+    return str(conf)
+
+
+def test_get_complete_root_statuses_parses_display_names(tmp_path):
+    conf = _write_conf(tmp_path, '\n'.join([
+        'bst.instance.Nougat64.enable_root_access="1"',
+        'bst.instance.Nougat64.display_name="Main Farm Bot"',
+        'bst.instance.Pie64.enable_root_access="0"',
+        'bst.instance.Pie64.display_name="Alt Account"',
+        'bst.instance.NoName.enable_root_access="1"',
+        'bst.feature.rooting="1"',
+    ]))
+
+    result = config_handler.get_complete_root_statuses(conf)
+
+    assert result["global_status"] is True
+    assert result["instance_statuses"] == {"Nougat64": True, "Pie64": False, "NoName": True}
+    assert result["display_names"] == {"Nougat64": "Main Farm Bot", "Pie64": "Alt Account"}
+
+
+def test_get_complete_root_statuses_missing_file_includes_display_names_key(tmp_path):
+    result = config_handler.get_complete_root_statuses(str(tmp_path / "does_not_exist.conf"))
+    assert result == {"global_status": False, "instance_statuses": {}, "display_names": {}}
+
+
+def test_get_complete_root_statuses_unreadable_file_includes_display_names_key(tmp_path, monkeypatch):
+    conf = _write_conf(tmp_path, 'bst.instance.Pie64.enable_root_access="1"')
+    monkeypatch.setattr(config_handler, "open", lambda *a, **k: (_ for _ in ()).throw(OSError("boom")), raising=False)
+
+    result = config_handler.get_complete_root_statuses(conf)
+    assert result == {"global_status": False, "instance_statuses": {}, "display_names": {}}

--- a/tests/test_instances_page.py
+++ b/tests/test_instances_page.py
@@ -1,4 +1,5 @@
 from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QLabel
 
 import constants
 from views.instances_page import InstancesPage
@@ -80,3 +81,51 @@ def test_clicking_fix_it_emits_go_to_dashboard(qtbot):
     page.show()
     with qtbot.waitSignal(page.go_to_dashboard_requested, timeout=1000):
         qtbot.mouseClick(page.banner_fix_button, Qt.LeftButton)
+
+
+def test_set_instances_shows_display_name_and_falls_back_to_unique_id(qtbot):
+    page = InstancesPage()
+    qtbot.addWidget(page)
+    page.show()
+    data = {
+        "Nougat64 (Normal)": {"root_enabled": True, "rw_mode": constants.MODE_READWRITE,
+                               "display_name": "Main Farm Bot"},
+        "Pie64 (Normal)": {"root_enabled": False, "rw_mode": constants.MODE_READWRITE},
+    }
+    page.set_instances(data)
+
+    labels = [page.instance_layout.itemAt(i).widget() for i in range(page.instance_layout.count())]
+    texts = {w.text() for w in labels if isinstance(w, QLabel)}
+    assert "Main Farm Bot" in texts
+    assert "Pie64 (Normal)" in texts  # no display_name key -> falls back to unique_id
+
+
+def test_set_instances_highlights_rooted_instances_green(qtbot):
+    page = InstancesPage()
+    qtbot.addWidget(page)
+    page.show()
+    data = {
+        "Rooted (Normal)": {"root_enabled": True, "rw_mode": constants.MODE_READWRITE},
+        "NotRooted (Normal)": {"root_enabled": False, "rw_mode": constants.MODE_READWRITE},
+    }
+    page.set_instances(data)
+
+    root_labels = {
+        w.text(): w for i in range(page.instance_layout.count())
+        if isinstance((w := page.instance_layout.itemAt(i).widget()), QLabel)
+        and w.text().startswith("Root:")
+    }
+    assert "green" in root_labels["Root: On"].styleSheet()
+    assert "green" not in root_labels["Root: Off"].styleSheet()
+
+
+def test_set_instances_refresh_does_not_leak_widgets(qtbot):
+    page = InstancesPage()
+    qtbot.addWidget(page)
+    page.show()
+    data = {"Pie64 (Normal)": {"root_enabled": True, "rw_mode": constants.MODE_READWRITE}}
+    page.set_instances(data)
+    count_after_first = page.instance_layout.count()
+
+    page.set_instances(data)
+    assert page.instance_layout.count() == count_after_first

--- a/views/instances_page.py
+++ b/views/instances_page.py
@@ -1,10 +1,10 @@
 """Instances page: instance grid + Toggle Root/R-W + patch-gating banner."""
 from __future__ import annotations
 
-from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QGridLayout, QGroupBox, QCheckBox, QLabel,
-    QPushButton, QHBoxLayout,
+    QPushButton, QHBoxLayout, QScrollArea,
 )
 
 import constants
@@ -32,13 +32,26 @@ class InstancesPage(QWidget):
         layout.addLayout(banner_row)
         self.set_engine_locked_banner(False)
 
+        # Instances group box: a scroll area wraps the grid so large instance
+        # counts (20+) don't force the window taller than the screen.
         self.instance_group = QGroupBox("Instances")
-        self.instance_layout = QGridLayout()
-        self.instance_layout.setColumnStretch(0, 4)
-        self.instance_layout.setColumnStretch(1, 1)
+        instance_group_layout = QVBoxLayout(self.instance_group)
+
+        self.instance_scroll_area = QScrollArea()
+        self.instance_scroll_area.setWidgetResizable(True)
+        self.instance_scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+        self.instance_scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+
+        self.instance_container = QWidget()
+        self.instance_layout = QGridLayout(self.instance_container)
+        self.instance_layout.setColumnStretch(0, 3)
+        self.instance_layout.setColumnStretch(1, 4)
         self.instance_layout.setColumnStretch(2, 1)
+        self.instance_layout.setColumnStretch(3, 1)
         self.instance_layout.setHorizontalSpacing(15)
-        self.instance_group.setLayout(self.instance_layout)
+
+        self.instance_scroll_area.setWidget(self.instance_container)
+        instance_group_layout.addWidget(self.instance_scroll_area)
         layout.addWidget(self.instance_group)
 
         button_row = QHBoxLayout()
@@ -73,11 +86,21 @@ class InstancesPage(QWidget):
             data = instance_data[unique_id]
             checkbox = QCheckBox(unique_id)
             checkbox.setChecked(unique_id in previous_selection)
-            root_text = "On" if data.get("root_enabled") else "Off"
+            display_name = data.get("display_name", unique_id)
+            root_on = bool(data.get("root_enabled"))
+            root_text = "On" if root_on else "Off"
             rw_text = "On" if data.get("rw_mode") == constants.MODE_READWRITE else "Off"
+
+            root_label = QLabel("Root: %s" % root_text)
+            if root_on:
+                root_label.setStyleSheet("background-color: green; color: white; padding: 2px;")
+            else:
+                root_label.setStyleSheet("padding: 2px;")
+
             self.instance_layout.addWidget(checkbox, row, 0)
-            self.instance_layout.addWidget(QLabel("Root: %s" % root_text), row, 1)
-            self.instance_layout.addWidget(QLabel("R/W: %s" % rw_text), row, 2)
+            self.instance_layout.addWidget(QLabel(display_name), row, 1)
+            self.instance_layout.addWidget(root_label, row, 2)
+            self.instance_layout.addWidget(QLabel("R/W: %s" % rw_text), row, 3)
             self.checkboxes[unique_id] = checkbox
 
     def selected_ids(self) -> list[str]:

--- a/views/main_window.py
+++ b/views/main_window.py
@@ -293,6 +293,7 @@ class MainWindow(QWidget):
             patch_mode = inst.get("patch_mode", False)
             root_info = config_handler.get_complete_root_statuses(config_path)
             instance_root_statuses = root_info['instance_statuses']
+            display_names = root_info.get('display_names', {})
 
             disk_instances = set()
             if os.path.isdir(data_path):
@@ -333,6 +334,7 @@ class MainWindow(QWidget):
                     "rw_mode": rw_mode,
                     "root_enabled": effective_root_status,
                     "individual_root_status": individual_root_on,
+                    "display_name": display_names.get(name, name),
                     "patch_mode": patch_mode,
                 }
 


### PR DESCRIPTION
## What & why

Closes #47 by porting it forward. #47 (display-name column, root-status color highlighting, scroll area for large instance lists) was written against the old single-file `main.py`. #45 merged first and replaced that file with the nav-rail `views/` layout, so #47 no longer applies and can't be rebased cleanly — the UI it touched doesn't exist in that shape anymore.

**All credit to Chris Borneman (@Hobbes4Pres)** — the feature, the config-parsing approach, and the scroll-area fix for his 20+-instance setup are his, from #47. This PR is that work carried onto the new file layout, plus the test coverage the original didn't have.

## Changes

- `constants.py` / `config_handler.py`: same approach as #47 — `DISPLAY_NAME_KEY`, `display_names` dict parsed alongside `instance_statuses`. Also closed a small gap #47 had: the `isfile()`-false early return was missing the `display_names` key that the exception-handler path got (per the Gemini review on #47) — now both empty-result paths agree on shape.
- `views/instances_page.py`: display-name column, green highlight on rooted rows, `QScrollArea` wrapping the grid (so 20+ instances don't push the window past screen height).
- `views/main_window.py`: wires `display_names` through `update_instance_data`.

## Testing

- New `tests/test_config_handler.py` + 4 new tests in `tests/test_instances_page.py` (display name + fallback, root-color highlighting, no widget leak across refresh). Confirmed each fails against pre-fix code before the change, passes after.
- Live-smoke-tested through the real `MainWindow` with 25 synthetic instances (mixed display names / rooted states): correct row count, correct highlight count (9/25 green), scroll area actually engaged (737px content in a fixed-height window), stable across a simulated refresh.
- Full suite: 81 passed. `ruff check --select E9,F63,F7,F82,F401 .` and `python -m compileall -q .` clean.

Closes #47.
