### PR TITLE
One-click Play Integrity Fix (PIFork) + honest integrity copy

### DIFF
--- a/pif_payload.py
+++ b/pif_payload.py
@@ -1,0 +1,87 @@
+"""Acquire the pinned Play Integrity Fork (PIFork) module.
+
+Play Integrity's BASIC and DEVICE verdicts gate on the guest looking like a
+Play-certified device: a valid build fingerprint and a set of "sensitive"
+system props. PIFork (osm0sis, the maintained successor to the abandoned PIF)
+spoofs those from a Zygisk module, and its bundled ``autopif`` fetches a fresh,
+Play-certified fingerprint so the default one being burned/banned isn't a
+problem. It's a Zygisk module, so it needs a working Zygisk -- on BlueStacks
+that's ReZygisk (see ``rezygisk_payload``).
+
+STRONG is a separate story: it needs a valid, unrevoked *hardware* keybox, which
+this tool neither ships nor can generate -- PIFork alone reaches BASIC + DEVICE.
+
+Like the other payloads, the module is **downloaded on demand, not vendored**:
+fetched from PIFork's own GitHub release, SHA-256-verified, and cached. Bumping
+the version is a one-line change: update ``MODULE_URL`` + ``MODULE_SHA256``
+(+ ``MODULE_SIZE``) together.
+
+Credit: Play Integrity Fork (c) osm0sis & chiteroman @ xda-developers.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+# --- Pinned module (official release, hash-locked) -------------------------
+# One-line version bump: change URL + SHA256 (+ SIZE) together.
+MODULE_NAME = "PlayIntegrityFork-v17.zip"
+MODULE_URL = (
+    "https://github.com/osm0sis/PlayIntegrityFork/releases/download/v17/"
+    "PlayIntegrityFork-v17.zip"
+)
+MODULE_SHA256 = "69115acdeba904a3b82882851cf3cb6c27aef5bfb6aa57c1988ab3a4c0bb8c87"
+MODULE_SIZE = 285020
+MODULE_VERSION = "v17"  # human-readable; move in lockstep with the pin
+
+
+def _sha256(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def fetch_module(cache_dir: str, progress=None) -> str:
+    """Return a path to the verified pinned PIFork zip, downloading + caching if
+    needed.
+
+    Re-verifies SHA-256 on every call; a cached file with the wrong hash is
+    re-downloaded.  Raises ``RuntimeError`` on a hash mismatch after download.
+    Hand the returned path to ``adb_handler.install_module``.
+    """
+    def _p(msg: str) -> None:
+        logger.info(msg)
+        if progress:
+            progress(msg)
+
+    os.makedirs(cache_dir, exist_ok=True)
+    dest = os.path.join(cache_dir, MODULE_NAME)
+    if os.path.isfile(dest):
+        try:
+            if _sha256(dest) == MODULE_SHA256:
+                _p("PIFork module present and verified (cached).")
+                return dest
+        except OSError:  # unreadable/locked cache -> fall through to re-download
+            pass
+
+    _p("Downloading Play Integrity Fork (%s)..." % MODULE_NAME)
+    tmp = dest + ".part"
+    try:
+        urllib.request.urlretrieve(MODULE_URL, tmp)  # pinned URL, hash-checked below
+        got = _sha256(tmp)
+        if got != MODULE_SHA256:
+            raise RuntimeError(
+                "PIFork module SHA-256 mismatch: got %s, expected %s"
+                % (got, MODULE_SHA256))
+        os.replace(tmp, dest)
+    finally:
+        if os.path.isfile(tmp):
+            os.unlink(tmp)
+    _p("PIFork module verified.")
+    return dest

--- a/tests/test_magisk_page.py
+++ b/tests/test_magisk_page.py
@@ -36,7 +36,7 @@ def test_empty_label_hidden_when_instances_present(qtbot):
 def test_no_action_buttons_shown_until_an_instance_is_selected(qtbot):
     page = _page(qtbot, {"Tiramisu64 (Normal)": None})
     for b in (page.install_button, page.uninstall_button, page.manager_button,
-              page.remove_manager_button, page.rezygisk_button):
+              page.remove_manager_button, page.rezygisk_button, page.pif_button):
         assert b.isVisibleTo(page) is False
 
 
@@ -46,7 +46,7 @@ def test_not_installed_shows_only_install(qtbot):
     assert page.install_button.isVisibleTo(page) is True
     assert page.install_button.isEnabled() is True
     for b in (page.uninstall_button, page.manager_button,
-              page.remove_manager_button, page.rezygisk_button):
+              page.remove_manager_button, page.rezygisk_button, page.pif_button):
         assert b.isVisibleTo(page) is False
     assert "not installed" in page.status_label.text().lower()
 
@@ -59,6 +59,7 @@ def test_installed_without_manager_shows_uninstall_and_install_manager(qtbot):
     assert page.manager_button.isVisibleTo(page) is True         # manager not in yet
     assert page.remove_manager_button.isVisibleTo(page) is False
     assert page.rezygisk_button.isVisibleTo(page) is False       # needs the manager first
+    assert page.pif_button.isVisibleTo(page) is False
 
 
 def test_installed_with_manager_unlocks_remove_manager_and_rezygisk(qtbot):
@@ -69,6 +70,7 @@ def test_installed_with_manager_unlocks_remove_manager_and_rezygisk(qtbot):
     assert page.manager_button.isVisibleTo(page) is False        # already installed
     assert page.remove_manager_button.isVisibleTo(page) is True
     assert page.rezygisk_button.isVisibleTo(page) is True
+    assert page.pif_button.isVisibleTo(page) is True
     assert "manager" in page.status_label.text()
 
 
@@ -78,7 +80,8 @@ def test_busy_forces_visible_action_buttons_disabled(qtbot):
     assert page.rezygisk_button.isEnabled() is True
 
     page.set_busy(True)
-    for b in (page.uninstall_button, page.remove_manager_button, page.rezygisk_button):
+    for b in (page.uninstall_button, page.remove_manager_button,
+              page.rezygisk_button, page.pif_button):
         assert b.isEnabled() is False
     # a selection change mid-op must not re-enable anything
     page._radios["Tiramisu64 (Normal)"].setChecked(False)
@@ -118,10 +121,12 @@ def test_manager_button_emits_signal_when_not_yet_installed(qtbot):
         qtbot.mouseClick(page.manager_button, Qt.LeftButton)
 
 
-def test_remove_manager_and_rezygisk_buttons_emit_signals(qtbot):
+def test_remove_manager_rezygisk_and_pif_buttons_emit_signals(qtbot):
     page = _page(qtbot, {"A (Normal)": _INSTALLED_MGR})
     _select(page, "A (Normal)")
     with qtbot.waitSignal(page.uninstall_manager_requested, timeout=1000):
         qtbot.mouseClick(page.remove_manager_button, Qt.LeftButton)
     with qtbot.waitSignal(page.install_rezygisk_requested, timeout=1000):
         qtbot.mouseClick(page.rezygisk_button, Qt.LeftButton)
+    with qtbot.waitSignal(page.install_pif_requested, timeout=1000):
+        qtbot.mouseClick(page.pif_button, Qt.LeftButton)

--- a/tests/test_main_window_magisk.py
+++ b/tests/test_main_window_magisk.py
@@ -183,3 +183,18 @@ def test_install_rezygisk_warns_when_adb_missing(qtbot, monkeypatch):
 
     warned.assert_called_once()
     ran.assert_not_called()
+
+
+def test_install_pif_runs_when_adb_present(qtbot, monkeypatch):
+    window = MainWindow()
+    qtbot.addWidget(window)
+    window.instance_data = _one_instance()
+    _select(window, status=_MGR)
+    monkeypatch.setattr("adb_handler.find_adb", lambda dirs: r"C:\bs\HD-Adb.exe")
+    monkeypatch.setattr("adb_handler.instance_adb_port", lambda c, n: 5555)
+    ran = MagicMock()
+    monkeypatch.setattr(window, "_run_async", ran)
+
+    window._handle_install_pif()
+
+    ran.assert_called_once()

--- a/tests/test_pif_payload.py
+++ b/tests/test_pif_payload.py
@@ -1,0 +1,62 @@
+"""Tests for pif_payload: pinned-module verification and caching.
+
+Network-free: the download path runs with a monkeypatched urlretrieve, so
+nothing here touches the real release or the wire.
+"""
+import hashlib
+import os
+
+import pytest
+
+import pif_payload as pp
+
+
+def test_fetch_module_returns_cached_when_hash_matches(tmp_path, monkeypatch):
+    payload = b"pretend-pifork-zip"
+    monkeypatch.setattr(pp, "MODULE_SHA256", hashlib.sha256(payload).hexdigest())
+    cached = tmp_path / pp.MODULE_NAME
+    cached.write_bytes(payload)
+
+    def _boom(*a, **k):
+        raise AssertionError("fetch_module downloaded despite a valid cached file")
+    monkeypatch.setattr(pp.urllib.request, "urlretrieve", _boom)
+
+    assert pp.fetch_module(str(tmp_path)) == str(cached)
+
+
+def test_fetch_module_redownloads_when_cache_unreadable(tmp_path, monkeypatch):
+    good = b"good-pifork-zip"
+    monkeypatch.setattr(pp, "MODULE_SHA256", hashlib.sha256(good).hexdigest())
+    cached = tmp_path / pp.MODULE_NAME
+    cached.write_bytes(b"placeholder-that-cannot-be-read")
+
+    real_sha = pp._sha256
+
+    def flaky_sha(path):
+        if os.path.abspath(path) == os.path.abspath(str(cached)):
+            raise OSError("locked")
+        return real_sha(path)
+    monkeypatch.setattr(pp, "_sha256", flaky_sha)
+
+    def fake_dl(url, dest):
+        with open(dest, "wb") as f:
+            f.write(good)
+    monkeypatch.setattr(pp.urllib.request, "urlretrieve", fake_dl)
+
+    assert pp.fetch_module(str(tmp_path)) == str(cached)
+    assert cached.read_bytes() == good
+
+
+def test_fetch_module_rejects_bad_hash_and_cleans_up(tmp_path, monkeypatch):
+    monkeypatch.setattr(pp, "MODULE_SHA256", "0" * 64)
+
+    def _fake_download(url, dest):
+        with open(dest, "wb") as f:
+            f.write(b"corrupted-or-tampered")
+    monkeypatch.setattr(pp.urllib.request, "urlretrieve", _fake_download)
+
+    with pytest.raises(RuntimeError, match="SHA-256 mismatch"):
+        pp.fetch_module(str(tmp_path))
+
+    assert not (tmp_path / (pp.MODULE_NAME + ".part")).exists()
+    assert not (tmp_path / pp.MODULE_NAME).exists()

--- a/views/magisk_page.py
+++ b/views/magisk_page.py
@@ -22,6 +22,7 @@ class MagiskPage(QWidget):
     install_manager_requested = pyqtSignal()
     uninstall_manager_requested = pyqtSignal()
     install_rezygisk_requested = pyqtSignal()
+    install_pif_requested = pyqtSignal()
 
     _EMPTY_TEXT = ("No instances detected yet. They appear here once BlueStacks "
                    "and its instances are found.")
@@ -29,11 +30,11 @@ class MagiskPage(QWidget):
     _INTEGRITY_NOTE = (
         "How this works: Magisk installs into the instance's system + data "
         "images while it's shut down (no R/W toggle, no temp-root, no taps). "
-        "After it finishes — start the instance, then click “Install "
-        "manager app”.\n\n"
-        "Play Integrity: with the right modules, Basic and Device are within "
-        "reach. STRONG relies on a hardware-backed keystore that emulators "
-        "don't have, so aim for Basic/Device here."
+        "After it finishes — start the instance, install the manager app, "
+        "then ReZygisk (Zygisk) and Play Integrity Fix, and reboot.\n\n"
+        "Play Integrity: Basic and Device pass with these modules. STRONG "
+        "additionally needs a valid, unrevoked hardware keybox that you supply "
+        "yourself — this tool can't and doesn't provide one."
     )
 
     def __init__(self, parent=None):
@@ -76,8 +77,14 @@ class MagiskPage(QWidget):
             "(magisk --install-module). Grant the su request in the manager, then "
             "reboot the instance to activate Zygisk.")
         self.rezygisk_button.clicked.connect(self.install_rezygisk_requested.emit)
+        self.pif_button = QPushButton("Install Play Integrity Fix")
+        self.pif_button.setToolTip(
+            "Downloads the pinned Play Integrity Fork (PIFork) module and flashes "
+            "it over ADB. Needs ReZygisk (Zygisk) active. Reaches Play Integrity "
+            "Basic + Device after a reboot; STRONG needs a keybox you supply.")
+        self.pif_button.clicked.connect(self.install_pif_requested.emit)
         for _b in (self.install_button, self.uninstall_button, self.manager_button,
-                   self.remove_manager_button, self.rezygisk_button):
+                   self.remove_manager_button, self.rezygisk_button, self.pif_button):
             button_row.addWidget(_b)
         layout.addLayout(button_row)
 
@@ -161,6 +168,7 @@ class MagiskPage(QWidget):
         self.manager_button.setVisible(installed and not manager)
         self.remove_manager_button.setVisible(manager)
         self.rezygisk_button.setVisible(manager)
+        self.pif_button.setVisible(manager)
         # A visible button is clickable unless a background op is running.
         busy = self._busy
         self.install_button.setEnabled(show_install and not busy)
@@ -168,3 +176,4 @@ class MagiskPage(QWidget):
         self.manager_button.setEnabled(installed and not manager and not busy)
         self.remove_manager_button.setEnabled(manager and not busy)
         self.rezygisk_button.setEnabled(manager and not busy)
+        self.pif_button.setEnabled(manager and not busy)

--- a/views/main_window.py
+++ b/views/main_window.py
@@ -27,6 +27,7 @@ import adb_handler
 import magisk_system
 import magisk_payload
 import rezygisk_payload
+import pif_payload
 import admin
 
 from views.nav_rail import (
@@ -184,6 +185,7 @@ class MainWindow(QWidget):
         self.magisk_page.install_manager_requested.connect(self._handle_install_manager)
         self.magisk_page.uninstall_manager_requested.connect(self._handle_uninstall_manager)
         self.magisk_page.install_rezygisk_requested.connect(self._handle_install_rezygisk)
+        self.magisk_page.install_pif_requested.connect(self._handle_install_pif)
 
         self.setMinimumWidth(700)
         self.setMinimumHeight(480)
@@ -714,12 +716,32 @@ class MainWindow(QWidget):
 
         self._run_async(job, "Installing ReZygisk into %s..." % uid)
 
+    def _handle_install_pif(self) -> None:
+        uid, instance = self._selected_magisk_instance()
+        if instance is None:
+            return
+        adb_exe, port = self._adb_and_port(instance)
+        if not adb_exe:
+            return
+
+        def job(progress):
+            def relay(msg):
+                progress(msg, -1)
+            progress("Fetching Play Integrity Fork...", -1)
+            zip_path = pif_payload.fetch_module(self._magisk_cache_dir(), progress=relay)
+            msg = adb_handler.install_module(adb_exe, port, zip_path, progress=relay)
+            self.show_notice.emit("Play Integrity Fix installed", msg)
+            return ("%s Reboot the instance, then check an integrity checker for "
+                    "Basic + Device." % msg)
+
+        self._run_async(job, "Installing Play Integrity Fix into %s..." % uid)
+
     def _action_buttons(self):
         return [self.instances_page.root_toggle_button, self.instances_page.rw_toggle_button,
                 self.dashboard_page.engine_button, self.modules_page.push_button,
                 self.magisk_page.install_button, self.magisk_page.uninstall_button,
                 self.magisk_page.manager_button, self.magisk_page.remove_manager_button,
-                self.magisk_page.rezygisk_button]
+                self.magisk_page.rezygisk_button, self.magisk_page.pif_button]
 
     def _set_busy(self, busy):
         for b in self._action_buttons():


### PR DESCRIPTION
Adds a pinned Play Integrity Fork (PIFork) module and an **Install Play Integrity Fix** button on the Magisk tab, so Play Integrity Basic + Device are a one-click flash on top of ReZygisk.

## What it does
- `pif_payload.py`: hash-locked, download-at-runtime fetch of `PlayIntegrityFork-v17.zip` (osm0sis), mirroring the ReZygisk payload — nothing vendored.
- Magisk tab: "Install Play Integrity Fix" button, shown once the manager is installed (like ReZygisk). Flashes over ADB (`fetch_module` → `install_module`). PIFork's autopif fetches a fresh Play-certified fingerprint, so the default-fingerprint-burned problem is handled.
- Rewrites the integrity note to state the real shape and drop "impossible": Basic and Device pass with these modules; STRONG additionally needs a valid, unrevoked hardware keybox the user supplies — this tool can't and doesn't provide one.

## Not yet live-verified
The code mirrors the proven ReZygisk path, but PIFork passing Basic/Device on BlueStacks specifically hasn't been confirmed on a booted instance yet. Recommend a live flash + integrity check before merge.

154 tests green.