### PR TITLE
Replace Play Integrity Fix with LSPosed + honest integrity copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,11 @@ This is the path for current BlueStacks (5.22.150.1014 and newer). You get root 
 > If a background BlueStacks auto-update later replaces the patched files, the Dashboard raises an **"auto-update reverted your engine patch"** alert with a **Re-patch now** button. See [Keep Root After Updates](#keep-root-after-updates) to stop it happening again.
 
 > [!TIP]
-> This gets **apps** working root — enough for most root-requiring apps and root checkers. If you want **Magisk/Kitsune-managed root with modules and hiding** (Zygisk, Play Integrity Fix, LSPosed, etc.), that's a separate, more involved setup with real emulator gotchas. It's documented in the companion guide: **[Root BlueStacks with Kitsune Mask → Magisk Modules & Hiding](https://github.com/RobThePCGuy/Root-Bluestacks-with-Kitsune-Mask#magisk-modules--hiding-advanced)**.
+> This gets **apps** working root — enough for most root-requiring apps and root checkers. If you want **Magisk/Kitsune-managed root with modules** (Zygisk via ReZygisk, LSPosed, etc.), that's a separate, more involved setup with real emulator gotchas. It's documented in the companion guide: **[Root BlueStacks with Kitsune Mask → Magisk Modules & Hiding](https://github.com/RobThePCGuy/Root-Bluestacks-with-Kitsune-Mask#magisk-modules--hiding-advanced)**. Note: Play Integrity does not pass on an emulator — Google limits that to its own Google Play Games — so integrity-gated apps won't work here regardless of modules.
 
 ### Magisk Modules, Kitsune Mask & Older Builds
 
-Everything past basic root — installing **Kitsune Mask** into `/system`, choosing and flashing **Magisk modules**, **hiding** (ReZygisk, LSPosed, Play Integrity Fix, module load order), and rooting **older or MSI builds** — lives in the companion guide, so it stays in one maintained place instead of being half-covered in two:
+Everything past basic root — installing **Kitsune Mask** into `/system`, choosing and flashing **Magisk modules** (ReZygisk, LSPosed, module load order), and rooting **older or MSI builds** — lives in the companion guide, so it stays in one maintained place instead of being half-covered in two:
 
 > [!TIP]
 > **➡️ [Root BlueStacks with Kitsune Mask](https://github.com/RobThePCGuy/Root-Bluestacks-with-Kitsune-Mask)** — the full written walkthrough.

--- a/lsposed_payload.py
+++ b/lsposed_payload.py
@@ -1,0 +1,88 @@
+"""Acquire the pinned LSPosed (Zygisk) module.
+
+LSPosed is the Xposed framework as a Zygisk module: it lets Xposed modules hook
+into apps on a rooted device. It needs a working Zygisk -- on BlueStacks that's
+ReZygisk (see ``rezygisk_payload``) -- and is a normal Magisk module, so it
+flashes with the same ``magisk --install-module`` path as any other module
+(``adb_handler.install_module``). After a reboot, modules are managed from the
+LSPosed app.
+
+This is NOT an integrity tool: it adds the Xposed hooking framework, nothing
+more. BlueStacks doesn't pass Play Integrity regardless of modules.
+
+Like the other payloads, the module is **downloaded on demand, not vendored**:
+fetched from LSPosed's own GitHub release, SHA-256-verified, and cached. We pin
+the **zygisk** variant (the riru variant is for the older Riru loader we don't
+use). Bumping the version is a one-line change: update ``MODULE_URL`` +
+``MODULE_SHA256`` (+ ``MODULE_SIZE``) together.
+
+Credit: LSPosed (c) LSPosed Developers, GPLv3.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+# --- Pinned module (official release, hash-locked) -------------------------
+# One-line version bump: change URL + SHA256 (+ SIZE) together. Use the *zygisk*
+# asset, not the riru one.
+MODULE_NAME = "LSPosed-v1.9.2-7024-zygisk-release.zip"
+MODULE_URL = (
+    "https://github.com/LSPosed/LSPosed/releases/download/v1.9.2/"
+    "LSPosed-v1.9.2-7024-zygisk-release.zip"
+)
+MODULE_SHA256 = "0ebc6bcb465d1c4b44b7220ab5f0252e6b4eb7fe43da74650476d2798bb29622"
+MODULE_SIZE = 2462055
+MODULE_VERSION = "v1.9.2 (7024)"  # human-readable; move in lockstep with the pin
+
+
+def _sha256(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def fetch_module(cache_dir: str, progress=None) -> str:
+    """Return a path to the verified pinned LSPosed zip, downloading + caching if
+    needed.
+
+    Re-verifies SHA-256 on every call; a cached file with the wrong hash is
+    re-downloaded.  Raises ``RuntimeError`` on a hash mismatch after download.
+    Hand the returned path to ``adb_handler.install_module``.
+    """
+    def _p(msg: str) -> None:
+        logger.info(msg)
+        if progress:
+            progress(msg)
+
+    os.makedirs(cache_dir, exist_ok=True)
+    dest = os.path.join(cache_dir, MODULE_NAME)
+    if os.path.isfile(dest):
+        try:
+            if _sha256(dest) == MODULE_SHA256:
+                _p("LSPosed module present and verified (cached).")
+                return dest
+        except OSError:  # unreadable/locked cache -> fall through to re-download
+            pass
+
+    _p("Downloading LSPosed (%s)..." % MODULE_NAME)
+    tmp = dest + ".part"
+    try:
+        urllib.request.urlretrieve(MODULE_URL, tmp)  # pinned URL, hash-checked below
+        got = _sha256(tmp)
+        if got != MODULE_SHA256:
+            raise RuntimeError(
+                "LSPosed module SHA-256 mismatch: got %s, expected %s"
+                % (got, MODULE_SHA256))
+        os.replace(tmp, dest)
+    finally:
+        if os.path.isfile(tmp):
+            os.unlink(tmp)
+    _p("LSPosed module verified.")
+    return dest

--- a/rezygisk_payload.py
+++ b/rezygisk_payload.py
@@ -1,8 +1,8 @@
 """Acquire the pinned ReZygisk module -- standalone Zygisk for the emulator.
 
 BlueStacks' guest kernel doesn't support Magisk's built-in Zygisk, so Zygisk
-(the API modules like Play Integrity Fix depend on) needs ReZygisk, a ptrace-
-based standalone Zygisk implementation.  ReZygisk is a normal Magisk module:
+(which Zygisk modules like LSPosed depend on) needs ReZygisk, a ptrace-based
+standalone Zygisk implementation.  ReZygisk is a normal Magisk module:
 once the DATABIN is complete (``util_functions.sh`` present), it flashes with the
 same ``magisk --install-module`` path as any other module -- see
 ``adb_handler.install_module``.

--- a/tests/test_lsposed_payload.py
+++ b/tests/test_lsposed_payload.py
@@ -1,0 +1,68 @@
+"""Tests for lsposed_payload: pinned-module verification and caching.
+
+Network-free: the download path runs with a monkeypatched urlretrieve, so
+nothing here touches the real release or the wire.
+"""
+import hashlib
+import os
+
+import pytest
+
+import lsposed_payload as lp
+
+
+def test_pins_the_zygisk_variant_not_riru():
+    # ReZygisk provides Zygisk; the riru asset is for the old Riru loader.
+    assert "zygisk" in lp.MODULE_NAME
+    assert "riru" not in lp.MODULE_NAME
+
+
+def test_fetch_module_returns_cached_when_hash_matches(tmp_path, monkeypatch):
+    payload = b"pretend-lsposed-zip"
+    monkeypatch.setattr(lp, "MODULE_SHA256", hashlib.sha256(payload).hexdigest())
+    cached = tmp_path / lp.MODULE_NAME
+    cached.write_bytes(payload)
+
+    def _boom(*a, **k):
+        raise AssertionError("fetch_module downloaded despite a valid cached file")
+    monkeypatch.setattr(lp.urllib.request, "urlretrieve", _boom)
+
+    assert lp.fetch_module(str(tmp_path)) == str(cached)
+
+
+def test_fetch_module_redownloads_when_cache_unreadable(tmp_path, monkeypatch):
+    good = b"good-lsposed-zip"
+    monkeypatch.setattr(lp, "MODULE_SHA256", hashlib.sha256(good).hexdigest())
+    cached = tmp_path / lp.MODULE_NAME
+    cached.write_bytes(b"placeholder-that-cannot-be-read")
+
+    real_sha = lp._sha256
+
+    def flaky_sha(path):
+        if os.path.abspath(path) == os.path.abspath(str(cached)):
+            raise OSError("locked")
+        return real_sha(path)
+    monkeypatch.setattr(lp, "_sha256", flaky_sha)
+
+    def fake_dl(url, dest):
+        with open(dest, "wb") as f:
+            f.write(good)
+    monkeypatch.setattr(lp.urllib.request, "urlretrieve", fake_dl)
+
+    assert lp.fetch_module(str(tmp_path)) == str(cached)
+    assert cached.read_bytes() == good
+
+
+def test_fetch_module_rejects_bad_hash_and_cleans_up(tmp_path, monkeypatch):
+    monkeypatch.setattr(lp, "MODULE_SHA256", "0" * 64)
+
+    def _fake_download(url, dest):
+        with open(dest, "wb") as f:
+            f.write(b"corrupted-or-tampered")
+    monkeypatch.setattr(lp.urllib.request, "urlretrieve", _fake_download)
+
+    with pytest.raises(RuntimeError, match="SHA-256 mismatch"):
+        lp.fetch_module(str(tmp_path))
+
+    assert not (tmp_path / (lp.MODULE_NAME + ".part")).exists()
+    assert not (tmp_path / lp.MODULE_NAME).exists()

--- a/tests/test_magisk_page.py
+++ b/tests/test_magisk_page.py
@@ -36,7 +36,7 @@ def test_empty_label_hidden_when_instances_present(qtbot):
 def test_no_action_buttons_shown_until_an_instance_is_selected(qtbot):
     page = _page(qtbot, {"Tiramisu64 (Normal)": None})
     for b in (page.install_button, page.uninstall_button, page.manager_button,
-              page.remove_manager_button, page.rezygisk_button):
+              page.remove_manager_button, page.rezygisk_button, page.lsposed_button):
         assert b.isVisibleTo(page) is False
 
 
@@ -46,7 +46,7 @@ def test_not_installed_shows_only_install(qtbot):
     assert page.install_button.isVisibleTo(page) is True
     assert page.install_button.isEnabled() is True
     for b in (page.uninstall_button, page.manager_button,
-              page.remove_manager_button, page.rezygisk_button):
+              page.remove_manager_button, page.rezygisk_button, page.lsposed_button):
         assert b.isVisibleTo(page) is False
     assert "not installed" in page.status_label.text().lower()
 
@@ -69,6 +69,7 @@ def test_installed_with_manager_unlocks_remove_manager_and_rezygisk(qtbot):
     assert page.manager_button.isVisibleTo(page) is False        # already installed
     assert page.remove_manager_button.isVisibleTo(page) is True
     assert page.rezygisk_button.isVisibleTo(page) is True
+    assert page.lsposed_button.isVisibleTo(page) is True
     assert "manager" in page.status_label.text()
 
 
@@ -78,7 +79,8 @@ def test_busy_forces_visible_action_buttons_disabled(qtbot):
     assert page.rezygisk_button.isEnabled() is True
 
     page.set_busy(True)
-    for b in (page.uninstall_button, page.remove_manager_button, page.rezygisk_button):
+    for b in (page.uninstall_button, page.remove_manager_button,
+              page.rezygisk_button, page.lsposed_button):
         assert b.isEnabled() is False
     # a selection change mid-op must not re-enable anything
     page._radios["Tiramisu64 (Normal)"].setChecked(False)
@@ -118,10 +120,12 @@ def test_manager_button_emits_signal_when_not_yet_installed(qtbot):
         qtbot.mouseClick(page.manager_button, Qt.LeftButton)
 
 
-def test_remove_manager_and_rezygisk_buttons_emit_signals(qtbot):
+def test_remove_manager_rezygisk_lsposed_buttons_emit_signals(qtbot):
     page = _page(qtbot, {"A (Normal)": _INSTALLED_MGR})
     _select(page, "A (Normal)")
     with qtbot.waitSignal(page.uninstall_manager_requested, timeout=1000):
         qtbot.mouseClick(page.remove_manager_button, Qt.LeftButton)
     with qtbot.waitSignal(page.install_rezygisk_requested, timeout=1000):
         qtbot.mouseClick(page.rezygisk_button, Qt.LeftButton)
+    with qtbot.waitSignal(page.install_lsposed_requested, timeout=1000):
+        qtbot.mouseClick(page.lsposed_button, Qt.LeftButton)

--- a/tests/test_main_window_magisk.py
+++ b/tests/test_main_window_magisk.py
@@ -183,3 +183,18 @@ def test_install_rezygisk_warns_when_adb_missing(qtbot, monkeypatch):
 
     warned.assert_called_once()
     ran.assert_not_called()
+
+
+def test_install_lsposed_runs_when_adb_present(qtbot, monkeypatch):
+    window = MainWindow()
+    qtbot.addWidget(window)
+    window.instance_data = _one_instance()
+    _select(window, status=_MGR)
+    monkeypatch.setattr("adb_handler.find_adb", lambda dirs: r"C:\bs\HD-Adb.exe")
+    monkeypatch.setattr("adb_handler.instance_adb_port", lambda c, n: 5555)
+    ran = MagicMock()
+    monkeypatch.setattr(window, "_run_async", ran)
+
+    window._handle_install_lsposed()
+
+    ran.assert_called_once()

--- a/views/magisk_page.py
+++ b/views/magisk_page.py
@@ -22,6 +22,7 @@ class MagiskPage(QWidget):
     install_manager_requested = pyqtSignal()
     uninstall_manager_requested = pyqtSignal()
     install_rezygisk_requested = pyqtSignal()
+    install_lsposed_requested = pyqtSignal()
 
     _EMPTY_TEXT = ("No instances detected yet. They appear here once BlueStacks "
                    "and its instances are found.")
@@ -29,11 +30,13 @@ class MagiskPage(QWidget):
     _INTEGRITY_NOTE = (
         "How this works: Magisk installs into the instance's system + data "
         "images while it's shut down (no R/W toggle, no temp-root, no taps). "
-        "After it finishes — start the instance, then click “Install "
-        "manager app”.\n\n"
-        "Play Integrity: with the right modules, Basic and Device are within "
-        "reach. STRONG relies on a hardware-backed keystore that emulators "
-        "don't have, so aim for Basic/Device here."
+        "Start the instance, install the manager app, then add modules: "
+        "ReZygisk (Zygisk — required by Zygisk modules) and LSPosed (the Xposed "
+        "framework for app-hooking modules). Reboot to activate.\n\n"
+        "Note on Play Integrity: it does not pass on BlueStacks. Google limits "
+        "emulator integrity to its own Google Play Games, so apps that gate on "
+        "it (banking, some games) won't work here — with or without these "
+        "modules. These give you root, Zygisk, and Xposed, not integrity."
     )
 
     def __init__(self, parent=None):
@@ -76,8 +79,14 @@ class MagiskPage(QWidget):
             "(magisk --install-module). Grant the su request in the manager, then "
             "reboot the instance to activate Zygisk.")
         self.rezygisk_button.clicked.connect(self.install_rezygisk_requested.emit)
+        self.lsposed_button = QPushButton("Install LSPosed (Xposed)")
+        self.lsposed_button.setToolTip(
+            "Downloads the pinned LSPosed (Zygisk) module and flashes it over ADB. "
+            "Needs ReZygisk (Zygisk) installed first. Reboot to activate; manage "
+            "modules from the LSPosed app.")
+        self.lsposed_button.clicked.connect(self.install_lsposed_requested.emit)
         for _b in (self.install_button, self.uninstall_button, self.manager_button,
-                   self.remove_manager_button, self.rezygisk_button):
+                   self.remove_manager_button, self.rezygisk_button, self.lsposed_button):
             button_row.addWidget(_b)
         layout.addLayout(button_row)
 
@@ -161,6 +170,7 @@ class MagiskPage(QWidget):
         self.manager_button.setVisible(installed and not manager)
         self.remove_manager_button.setVisible(manager)
         self.rezygisk_button.setVisible(manager)
+        self.lsposed_button.setVisible(manager)
         # A visible button is clickable unless a background op is running.
         busy = self._busy
         self.install_button.setEnabled(show_install and not busy)
@@ -168,3 +178,4 @@ class MagiskPage(QWidget):
         self.manager_button.setEnabled(installed and not manager and not busy)
         self.remove_manager_button.setEnabled(manager and not busy)
         self.rezygisk_button.setEnabled(manager and not busy)
+        self.lsposed_button.setEnabled(manager and not busy)

--- a/views/main_window.py
+++ b/views/main_window.py
@@ -27,6 +27,7 @@ import adb_handler
 import magisk_system
 import magisk_payload
 import rezygisk_payload
+import lsposed_payload
 import admin
 
 from views.nav_rail import (
@@ -184,6 +185,7 @@ class MainWindow(QWidget):
         self.magisk_page.install_manager_requested.connect(self._handle_install_manager)
         self.magisk_page.uninstall_manager_requested.connect(self._handle_uninstall_manager)
         self.magisk_page.install_rezygisk_requested.connect(self._handle_install_rezygisk)
+        self.magisk_page.install_lsposed_requested.connect(self._handle_install_lsposed)
 
         self.setMinimumWidth(700)
         self.setMinimumHeight(480)
@@ -714,12 +716,32 @@ class MainWindow(QWidget):
 
         self._run_async(job, "Installing ReZygisk into %s..." % uid)
 
+    def _handle_install_lsposed(self) -> None:
+        uid, instance = self._selected_magisk_instance()
+        if instance is None:
+            return
+        adb_exe, port = self._adb_and_port(instance)
+        if not adb_exe:
+            return
+
+        def job(progress):
+            def relay(msg):
+                progress(msg, -1)
+            progress("Fetching LSPosed...", -1)
+            zip_path = lsposed_payload.fetch_module(self._magisk_cache_dir(), progress=relay)
+            msg = adb_handler.install_module(adb_exe, port, zip_path, progress=relay)
+            self.show_notice.emit("LSPosed installed", msg)
+            return ("%s Reboot the instance to activate it (needs ReZygisk); then "
+                    "manage modules from the LSPosed app." % msg)
+
+        self._run_async(job, "Installing LSPosed into %s..." % uid)
+
     def _action_buttons(self):
         return [self.instances_page.root_toggle_button, self.instances_page.rw_toggle_button,
                 self.dashboard_page.engine_button, self.modules_page.push_button,
                 self.magisk_page.install_button, self.magisk_page.uninstall_button,
                 self.magisk_page.manager_button, self.magisk_page.remove_manager_button,
-                self.magisk_page.rezygisk_button]
+                self.magisk_page.rezygisk_button, self.magisk_page.lsposed_button]
 
     def _set_busy(self, busy):
         for b in self._action_buttons():


### PR DESCRIPTION
Cuts the (unmerged) Play Integrity Fix feature and adds **LSPosed** instead, plus corrects integrity copy that overclaimed.

## Why cut PIF
On BlueStacks a green Play Integrity verdict isn't reachable — Google gates emulator integrity to `MEETS_VIRTUAL_INTEGRITY`, which is exclusive to Google Play Games. We confirmed it empirically (root hidden via MagiskHide + fresh Pixel fingerprint spoofing in DroidGuard + fresh security patch + a clean GMS still returns no verdict), and no BlueStacks rooter — including the polished competitors — claims to pass it. Shipping a PIF button implied a capability the platform can't deliver.

## What's added
- `lsposed_payload.py`: pinned, hash-locked **LSPosed v1.9.2 (7024)** zygisk variant, download-at-runtime, mirroring the ReZygisk payload.
- Magisk tab: **Install LSPosed (Xposed)** button (fetch → `install_module`), shown once the manager is installed, like ReZygisk. Needs ReZygisk (Zygisk) first.
- Rewrote the module note: it no longer says Basic/Device are "within reach." Honest framing — these modules give **root, Zygisk, and Xposed**, not Play Integrity, which does not pass on an emulator.
- README: dropped "Play Integrity Fix" from the module lists and added the integrity caveat.

155 tests green.