### PR TITLE
Privacy tab: offline guest ad/telemetry hosts blocker

### DIFF
--- a/telemetry_block.py
+++ b/telemetry_block.py
@@ -1,0 +1,273 @@
+"""Offline ad/telemetry blocking for a BlueStacks instance's guest hosts file.
+
+Why this exists
+---------------
+BlueStacks and the apps inside it phone home to ad networks and analytics
+endpoints -- and the in-app "disable ads" toggle only covers a fraction of it
+(a live capture still shows the player reaching an ad-exchange like rtbhouse
+with that toggle off).  The surgical, emulator-only fix is the classic Android
+ad-block approach: null-route the ad/tracker domains in the guest's
+``/system/etc/hosts``.  This affects **only the emulator's guest**, never the
+user's Windows machine (unlike a system-wide hosts edit), and it's fully
+reversible.
+
+How it works
+------------
+``/system/etc/hosts`` lives in the guest system tree inside ``Root.vhd`` (mounted
+read-only by the hypervisor at runtime), so it's edited **offline** while the
+instance is shut down -- the same ``diskpart``-attach + bundled ``debugfs`` path
+the Magisk install uses.  ``apply`` backs up the current hosts (host-side
+sidecar), then writes ``<original, minus any prior block> + a marked block`` of
+``0.0.0.0 <domain>`` lines.  ``remove`` restores the backup.  Because the block
+lives between explicit markers, re-applying is idempotent and removal is exact.
+
+The block list is intentionally conservative: clear third-party ad/analytics
+networks plus the ad exchange seen in a live capture -- nothing that Google Play,
+GMS, or an app's own servers need.  It's meant to be extended from a live capture
+of a given build (``README`` in this module explains the capture step).
+
+Note: ``Root.vhd`` is shared across all instances of one Android version, so the
+block applies to every instance of that version -- which is what you want for a
+telemetry block.
+
+Requirements: Windows, Administrator (raw-disk access + diskpart), instance shut
+down.
+"""
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+import os
+import tempfile
+
+import ext4_symlink as _es
+import magisk_system as _ms
+
+logger = logging.getLogger(__name__)
+
+_BLOCK_BEGIN = "# >>> BlueStacksRootGUI ad/telemetry block >>>"
+_BLOCK_END = "# <<< BlueStacksRootGUI ad/telemetry block <<<"
+_BACKUP_NAME = ".hosts_prelock.bak"       # host-side: original hosts before first block
+_STATE_NAME = ".telemetry_block.json"     # host-side: applied? + provenance
+
+# Null-routed domains. Conservative on purpose -- clear third-party ad networks,
+# mobile-attribution SDKs, and the ad exchange caught in a live capture. NOT
+# Google Play / GMS infrastructure, NOT an app's own backend. Extend from a live
+# capture of the target build (see module docstring).
+BLOCKLIST = (
+    # ad exchange seen phoning home from the player itself (live capture)
+    "rtbhouse.net",
+    # generic ad serving
+    "doubleclick.net",
+    "googlesyndication.com",
+    "googleadservices.com",
+    # third-party mobile ad networks
+    "applovin.com",
+    "applvn.com",
+    "adcolony.com",
+    "chartboost.com",
+    "inmobi.com",
+    "vungle.com",
+    "tapjoy.com",
+    "mopub.com",
+    "supersonicads.com",
+    "ironsrc.com",
+    "unityads.unity3d.com",
+    "flurry.com",
+    "adtilt.com",
+    # mobile attribution / tracking SDKs
+    "appsflyer.com",
+    "adjust.com",
+    "kochava.com",
+)
+
+
+def _instance_paths(instance_dir: str) -> tuple[str, str]:
+    return (os.path.join(instance_dir, _BACKUP_NAME),
+            os.path.join(instance_dir, _STATE_NAME))
+
+
+def _block_text() -> str:
+    """The marked block of ``0.0.0.0 <domain>`` lines (both the bare domain and
+    its ``www.`` alias)."""
+    lines = [_BLOCK_BEGIN]
+    for d in BLOCKLIST:
+        lines.append("0.0.0.0 %s" % d)
+        lines.append("0.0.0.0 www.%s" % d)
+    lines.append(_BLOCK_END)
+    return "\n".join(lines) + "\n"
+
+
+def _strip_block(text: str) -> str:
+    """``text`` with any existing marked block removed (idempotent re-apply)."""
+    out: list[str] = []
+    skipping = False
+    for line in text.splitlines():
+        s = line.strip()
+        if s == _BLOCK_BEGIN:
+            skipping = True
+            continue
+        if s == _BLOCK_END:
+            skipping = False
+            continue
+        if not skipping:
+            out.append(line)
+    body = "\n".join(out).rstrip("\n")
+    return (body + "\n") if body else ""
+
+
+def has_block(text: str) -> bool:
+    return _BLOCK_BEGIN in text
+
+
+def _hosts_ext4(sysroot: str) -> str:
+    return "%s/etc/hosts" % sysroot
+
+
+def _dump_hosts(device: str, sysroot: str, env: dict) -> str:
+    """Return the current guest hosts content (empty string if absent)."""
+    fd, tmp = tempfile.mkstemp(suffix="-hosts")
+    os.close(fd)
+    try:
+        _es._run([_es._debugfs(), "-R",
+                  "dump %s %s" % (_hosts_ext4(sysroot), _ms._cygpath(tmp)), device],
+                 env=env)
+        try:
+            with open(tmp, encoding="utf-8", errors="replace") as f:
+                return f.read()
+        except OSError:
+            return ""
+    finally:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+
+
+def _write_hosts(device: str, sysroot: str, content: str, env: dict) -> str:
+    """Write ``content`` to the guest hosts (0644 root:root). Returns debugfs
+    output. Rewrites in place: rm then write a bare name in the CWD (debugfs
+    quirk), matching magisk_system's writer."""
+    fd, tmp = tempfile.mkstemp(suffix="-hosts")
+    with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as f:
+        f.write(content)
+    try:
+        etcdir = "%s/etc" % sysroot
+        hosts = _hosts_ext4(sysroot)
+        cmds = ["cd %s" % etcdir, "rm hosts",
+                "write %s hosts" % _ms._dq(_ms._cygpath(tmp)),
+                "sif %s mode 0100644" % hosts,
+                "sif %s uid 0" % hosts, "sif %s gid 0" % hosts]
+        return _es._run_script(device, cmds, env)
+    finally:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+
+
+def _write_state(instance_dir: str, applied: bool) -> None:
+    _, state = _instance_paths(instance_dir)
+    if not applied:
+        try:
+            os.unlink(state)
+        except OSError:
+            pass
+        return
+    data = {"telemetry_block": True,
+            "domains": len(BLOCKLIST),
+            "applied_at": datetime.datetime.now().isoformat(timespec="seconds")}
+    try:
+        with open(state, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+    except OSError as exc:
+        logger.warning("could not write telemetry-block state: %s", exc)
+
+
+def status(instance_dir: str) -> dict | None:
+    """The block state sidecar, or None if not applied. For the GUI."""
+    _, state = _instance_paths(instance_dir)
+    try:
+        with open(state, encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, ValueError):
+        return None
+
+
+def apply(instance_dir: str, progress=None) -> list[str]:
+    """Null-route the ad/telemetry domains in the instance's guest hosts.
+    Backs up the original once, is idempotent, and verifies the filesystem."""
+    def _p(msg: str) -> None:
+        logger.info(msg)
+        if progress:
+            progress(msg)
+
+    if not _es.tools_available():
+        raise RuntimeError("bundled e2fsprogs (debugfs) not found")
+    root_vhd = _ms._resolve_root_vhd(instance_dir)
+    backup, _ = _instance_paths(instance_dir)
+    env = _es._tool_env()
+
+    _p("Attaching Root.vhd (blocking ad/telemetry hosts)...")
+    with _es._Attached(root_vhd) as att:
+        dev = att.device
+        sysroot = _ms._find_system_root(dev, env)
+        current = _dump_hosts(dev, sysroot, env)
+        base = _strip_block(current)
+        # Preserve the pre-block original once, so remove() restores it exactly.
+        if not os.path.isfile(backup):
+            try:
+                with open(backup, "w", encoding="utf-8", newline="\n") as f:
+                    f.write(base)
+            except OSError as exc:
+                logger.warning("could not save hosts backup: %s", exc)
+        new = base + _block_text()
+        _p("Writing %d blocked domains into guest hosts..." % len(BLOCKLIST))
+        out = _write_hosts(dev, sysroot, new, env)
+        written = _dump_hosts(dev, sysroot, env)
+        if not has_block(written):
+            raise RuntimeError("hosts block not written (debugfs: %s)" % _ms._errtail(out))
+        _p("Verifying filesystem (e2fsck)...")
+        if not _es._fsck_ok(dev, env):
+            raise RuntimeError("e2fsck reported errors after writing hosts")
+    _write_state(instance_dir, True)
+    return ["Blocked %d ad/telemetry domains in the guest hosts file." % len(BLOCKLIST)]
+
+
+def remove(instance_dir: str, progress=None) -> list[str]:
+    """Restore the guest hosts to its pre-block state."""
+    def _p(msg: str) -> None:
+        logger.info(msg)
+        if progress:
+            progress(msg)
+
+    if not _es.tools_available():
+        return ["e2fsprogs unavailable -- nothing to remove"]
+    try:
+        root_vhd = _ms._resolve_root_vhd(instance_dir)
+    except RuntimeError:
+        return ["Root.vhd not found -- nothing to remove"]
+    backup, _ = _instance_paths(instance_dir)
+    env = _es._tool_env()
+
+    _p("Attaching Root.vhd (restoring guest hosts)...")
+    with _es._Attached(root_vhd) as att:
+        dev = att.device
+        sysroot = _ms._find_system_root(dev, env)
+        if os.path.isfile(backup):
+            with open(backup, encoding="utf-8", errors="replace") as f:
+                base = f.read()
+        else:  # no backup: just strip our block from whatever is there
+            base = _strip_block(_dump_hosts(dev, sysroot, env))
+        if not base.strip():
+            base = "127.0.0.1\tlocalhost\n::1\t\tlocalhost\n"  # stock fallback
+        _write_hosts(dev, sysroot, base, env)
+        if not _es._fsck_ok(dev, env):
+            raise RuntimeError("e2fsck reported errors after restoring hosts")
+    _write_state(instance_dir, False)
+    try:
+        os.unlink(backup)
+    except OSError:
+        pass
+    return ["Restored the guest hosts file (ad/telemetry block removed)."]

--- a/tests/test_nav_rail.py
+++ b/tests/test_nav_rail.py
@@ -1,6 +1,6 @@
 from PyQt5.QtCore import Qt
 
-from views.nav_rail import NavRail, DASHBOARD, INSTANCES, MAGISK, MODULES
+from views.nav_rail import NavRail, DASHBOARD, INSTANCES, MAGISK, MODULES, PRIVACY
 
 
 def test_nav_rail_starts_on_dashboard(qtbot):
@@ -18,6 +18,16 @@ def test_nav_rail_has_magisk_destination(qtbot):
         qtbot.mouseClick(rail._buttons[MAGISK], Qt.LeftButton)
     assert blocker.args == [MAGISK]
     assert rail.current() == MAGISK
+
+
+def test_nav_rail_has_privacy_destination(qtbot):
+    rail = NavRail()
+    qtbot.addWidget(rail)
+    assert PRIVACY in rail._buttons
+    with qtbot.waitSignal(rail.navigate, timeout=1000) as blocker:
+        qtbot.mouseClick(rail._buttons[PRIVACY], Qt.LeftButton)
+    assert blocker.args == [PRIVACY]
+    assert rail.current() == PRIVACY
 
 
 def test_clicking_instances_emits_navigate_and_updates_active_state(qtbot):

--- a/tests/test_privacy_page.py
+++ b/tests/test_privacy_page.py
@@ -1,0 +1,64 @@
+from PyQt5.QtCore import Qt
+
+from views.privacy_page import PrivacyPage
+
+_BLOCKED = {"telemetry_block": True, "domains": 19}
+
+
+def _page(qtbot, statuses=None):
+    page = PrivacyPage()
+    qtbot.addWidget(page)
+    page.show()
+    if statuses is not None:
+        page.set_instances(statuses)
+    return page
+
+
+def test_empty_label_shown_when_no_instances(qtbot):
+    page = _page(qtbot, {})
+    assert page.no_instances_label.isVisible() is True
+
+
+def test_no_buttons_until_instance_selected(qtbot):
+    page = _page(qtbot, {"A (Normal)": None})
+    assert page.block_button.isVisibleTo(page) is False
+    assert page.unblock_button.isVisibleTo(page) is False
+
+
+def test_not_blocked_shows_block_only(qtbot):
+    page = _page(qtbot, {"A (Normal)": None})
+    page._radios["A (Normal)"].setChecked(True)
+    assert page.block_button.isVisibleTo(page) is True
+    assert page.block_button.isEnabled() is True
+    assert page.unblock_button.isVisibleTo(page) is False
+    assert "no telemetry block" in page.status_label.text().lower()
+
+
+def test_blocked_shows_remove_only(qtbot):
+    page = _page(qtbot, {"A (Normal)": _BLOCKED})
+    page._radios["A (Normal)"].setChecked(True)
+    assert page.block_button.isVisibleTo(page) is False
+    assert page.unblock_button.isVisibleTo(page) is True
+    assert "19" in page.status_label.text()
+
+
+def test_busy_disables_visible_button(qtbot):
+    page = _page(qtbot, {"A (Normal)": _BLOCKED})
+    page._radios["A (Normal)"].setChecked(True)
+    assert page.unblock_button.isEnabled() is True
+    page.set_busy(True)
+    assert page.unblock_button.isEnabled() is False
+    page.set_busy(False)
+    assert page.unblock_button.isEnabled() is True
+
+
+def test_buttons_emit_signals(qtbot):
+    page = _page(qtbot, {"A (Normal)": None})
+    page._radios["A (Normal)"].setChecked(True)
+    with qtbot.waitSignal(page.block_requested, timeout=1000):
+        qtbot.mouseClick(page.block_button, Qt.LeftButton)
+
+    page.set_instances({"A (Normal)": _BLOCKED})
+    page._radios["A (Normal)"].setChecked(True)
+    with qtbot.waitSignal(page.unblock_requested, timeout=1000):
+        qtbot.mouseClick(page.unblock_button, Qt.LeftButton)

--- a/tests/test_telemetry_block.py
+++ b/tests/test_telemetry_block.py
@@ -1,0 +1,58 @@
+"""Tests for telemetry_block's pure/state logic.
+
+The offline disk write itself is validated live (it needs an attached Root.vhd
++ Administrator). Here we lock in the marked-block generation, idempotent
+strip/re-apply, and the state sidecar.
+"""
+import telemetry_block as tb
+
+
+def test_blocklist_is_nonempty_lowercase_domains():
+    assert tb.BLOCKLIST
+    for d in tb.BLOCKLIST:
+        assert d == d.lower() and " " not in d and "/" not in d
+    # the ad exchange caught in the live capture is in the list
+    assert "rtbhouse.net" in tb.BLOCKLIST
+
+
+def test_block_text_markers_and_null_routes():
+    text = tb._block_text()
+    assert tb._BLOCK_BEGIN in text and tb._BLOCK_END in text
+    for d in tb.BLOCKLIST:
+        assert "0.0.0.0 %s" % d in text
+        assert "0.0.0.0 www.%s" % d in text  # www alias too
+    assert tb.has_block(text) is True
+
+
+def test_strip_block_removes_only_the_marked_section():
+    original = "127.0.0.1\tlocalhost\n::1\t\tlocalhost\n"
+    blocked = original + tb._block_text()
+    assert tb.has_block(blocked) is True
+    stripped = tb._strip_block(blocked)
+    assert tb.has_block(stripped) is False
+    # the user's real hosts entries survive
+    assert "127.0.0.1\tlocalhost" in stripped
+    assert "rtbhouse.net" not in stripped
+
+
+def test_apply_is_idempotent_no_double_block():
+    original = "127.0.0.1 localhost\n"
+    once = tb._strip_block(original) + tb._block_text()
+    # re-applying strips the prior block first, so there's exactly one
+    twice = tb._strip_block(once) + tb._block_text()
+    assert twice.count(tb._BLOCK_BEGIN) == 1
+    assert once == twice
+
+
+def test_has_block_false_on_plain_hosts():
+    assert tb.has_block("127.0.0.1 localhost\n") is False
+
+
+def test_state_sidecar_roundtrip(tmp_path):
+    assert tb.status(str(tmp_path)) is None
+    tb._write_state(str(tmp_path), True)
+    st = tb.status(str(tmp_path))
+    assert st["telemetry_block"] is True
+    assert st["domains"] == len(tb.BLOCKLIST)
+    tb._write_state(str(tmp_path), False)
+    assert tb.status(str(tmp_path)) is None

--- a/views/main_window.py
+++ b/views/main_window.py
@@ -28,16 +28,18 @@ import magisk_system
 import magisk_payload
 import rezygisk_payload
 import lsposed_payload
+import telemetry_block
 import admin
 
 from views.nav_rail import (
     NavRail, DASHBOARD as NAV_DASHBOARD, INSTANCES as NAV_INSTANCES,
-    MAGISK as NAV_MAGISK, MODULES as NAV_MODULES,
+    MAGISK as NAV_MAGISK, MODULES as NAV_MODULES, PRIVACY as NAV_PRIVACY,
 )
 from views.dashboard_page import DashboardPage
 from views.instances_page import InstancesPage
 from views.magisk_page import MagiskPage
 from views.modules_page import ModulesPage
+from views.privacy_page import PrivacyPage
 from views.progress import OperationProgressBar, step_percent
 from views import theme
 from views import engine_rules
@@ -155,15 +157,18 @@ class MainWindow(QWidget):
         self.instances_page = InstancesPage()
         self.magisk_page = MagiskPage()
         self.modules_page = ModulesPage()
+        self.privacy_page = PrivacyPage()
         self.pages.addWidget(self.dashboard_page)
         self.pages.addWidget(self.instances_page)
         self.pages.addWidget(self.magisk_page)
         self.pages.addWidget(self.modules_page)
+        self.pages.addWidget(self.privacy_page)
         self._pages_by_key = {
             NAV_DASHBOARD: self.dashboard_page,
             NAV_INSTANCES: self.instances_page,
             NAV_MAGISK: self.magisk_page,
             NAV_MODULES: self.modules_page,
+            NAV_PRIVACY: self.privacy_page,
         }
         body.addWidget(self.pages, 1)
 
@@ -186,6 +191,8 @@ class MainWindow(QWidget):
         self.magisk_page.uninstall_manager_requested.connect(self._handle_uninstall_manager)
         self.magisk_page.install_rezygisk_requested.connect(self._handle_install_rezygisk)
         self.magisk_page.install_lsposed_requested.connect(self._handle_install_lsposed)
+        self.privacy_page.block_requested.connect(self._handle_block_telemetry)
+        self.privacy_page.unblock_requested.connect(self._handle_unblock_telemetry)
 
         self.setMinimumWidth(700)
         self.setMinimumHeight(480)
@@ -196,6 +203,8 @@ class MainWindow(QWidget):
             self._refresh_running_instances()
         elif key == NAV_MAGISK:
             self._refresh_magisk_statuses()
+        elif key == NAV_PRIVACY:
+            self._refresh_privacy_statuses()
 
     def _handle_toggle_theme(self) -> None:
         current = theme.load_saved_theme()
@@ -575,6 +584,59 @@ class MainWindow(QWidget):
                     for uid, data in self.instance_data.items()}
         self.magisk_page.set_instances(statuses)
 
+    def _refresh_privacy_statuses(self) -> None:
+        """Fill the Privacy tab with each instance's telemetry-block state."""
+        statuses = {uid: telemetry_block.status(data["data_path"])
+                    for uid, data in self.instance_data.items()}
+        self.privacy_page.set_instances(statuses)
+
+    def _handle_block_telemetry(self) -> None:
+        uid = self.privacy_page.selected_instance_id()
+        if not uid or uid not in self.instance_data:
+            QMessageBox.information(self, "No instance selected",
+                                    "Select an instance on the Privacy tab first.")
+            return
+        if not self._confirm(
+                "Block ads & telemetry",
+                "Block ad/telemetry domains in %s?" % uid,
+                "<p>Null-routes ad, tracker, and analytics domains in the guest "
+                "hosts file while the instance is shut down (all BlueStacks "
+                "processes close first). Emulator-only, and reversible.</p>"):
+            return
+        data_path = self.instance_data[uid]["data_path"]
+
+        def job(progress):
+            progress("Closing BlueStacks...", 0)
+            instance_handler.terminate_bluestacks()
+            QThread.msleep(constants.PROCESS_TERMINATION_WAIT_MS)
+            results = telemetry_block.apply(data_path, progress=lambda m: progress(m, -1))
+            return results[-1] if results else "Telemetry blocked."
+
+        self._run_async(job, "Blocking ads/telemetry in %s..." % uid)
+
+    def _handle_unblock_telemetry(self) -> None:
+        uid = self.privacy_page.selected_instance_id()
+        if not uid or uid not in self.instance_data:
+            QMessageBox.information(self, "No instance selected",
+                                    "Select an instance on the Privacy tab first.")
+            return
+        if not self._confirm(
+                "Remove telemetry block",
+                "Restore the original guest hosts file for %s?" % uid,
+                "<p>Removes the ad/telemetry block, while the instance is shut "
+                "down (all BlueStacks processes close first).</p>"):
+            return
+        data_path = self.instance_data[uid]["data_path"]
+
+        def job(progress):
+            progress("Closing BlueStacks...", 0)
+            instance_handler.terminate_bluestacks()
+            QThread.msleep(constants.PROCESS_TERMINATION_WAIT_MS)
+            results = telemetry_block.remove(data_path, progress=lambda m: progress(m, -1))
+            return results[-1] if results else "Block removed."
+
+        self._run_async(job, "Removing the block from %s..." % uid)
+
     def _selected_magisk_instance(self):
         uid = self.magisk_page.selected_instance_id()
         if not uid or uid not in self.instance_data:
@@ -741,7 +803,8 @@ class MainWindow(QWidget):
                 self.dashboard_page.engine_button, self.modules_page.push_button,
                 self.magisk_page.install_button, self.magisk_page.uninstall_button,
                 self.magisk_page.manager_button, self.magisk_page.remove_manager_button,
-                self.magisk_page.rezygisk_button, self.magisk_page.lsposed_button]
+                self.magisk_page.rezygisk_button, self.magisk_page.lsposed_button,
+                self.privacy_page.block_button, self.privacy_page.unblock_button]
 
     def _set_busy(self, busy):
         for b in self._action_buttons():
@@ -751,6 +814,7 @@ class MainWindow(QWidget):
         # would re-enable themselves mid-operation.
         self.modules_page.set_busy(busy)
         self.magisk_page.set_busy(busy)
+        self.privacy_page.set_busy(busy)
         if busy:
             self.status_refresh_timer.stop()
 
@@ -817,6 +881,8 @@ class MainWindow(QWidget):
             self._refresh_running_instances()
         elif self.nav_rail.current() == NAV_MAGISK:
             self._refresh_magisk_statuses()
+        elif self.nav_rail.current() == NAV_PRIVACY:
+            self._refresh_privacy_statuses()
         self.status_refresh_timer.start(constants.REFRESH_INTERVAL_MS)
 
     def _cleanup_async(self):

--- a/views/nav_rail.py
+++ b/views/nav_rail.py
@@ -1,4 +1,4 @@
-"""Left navigation rail: Dashboard / Instances / Magisk / Modules."""
+"""Left navigation rail: Dashboard / Instances / Magisk / Modules / Privacy."""
 from __future__ import annotations
 
 from PyQt5.QtCore import pyqtSignal
@@ -8,17 +8,19 @@ DASHBOARD = "dashboard"
 INSTANCES = "instances"
 MAGISK = "magisk"
 MODULES = "modules"
+PRIVACY = "privacy"
 
 _DESTINATIONS = [
     (DASHBOARD, "Dashboard"),
     (INSTANCES, "Instances"),
     (MAGISK, "Magisk"),
     (MODULES, "Modules"),
+    (PRIVACY, "Privacy"),
 ]
 
 
 class NavRail(QFrame):
-    """Emits ``navigate(str)`` with one of DASHBOARD/INSTANCES/MAGISK/MODULES."""
+    """Emits ``navigate(str)`` with a destination key (see _DESTINATIONS)."""
 
     navigate = pyqtSignal(str)
 

--- a/views/privacy_page.py
+++ b/views/privacy_page.py
@@ -1,0 +1,130 @@
+"""Privacy page: block ad/telemetry domains in an instance's guest hosts file.
+
+Offline + reversible, per Android version (Root.vhd is shared across instances
+of a version). Emulator-only -- never touches the user's Windows hosts.
+"""
+from __future__ import annotations
+
+from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QRadioButton, QButtonGroup,
+    QPushButton,
+)
+
+
+class PrivacyPage(QWidget):
+    block_requested = pyqtSignal()
+    unblock_requested = pyqtSignal()
+
+    _EMPTY_TEXT = ("No instances detected yet. They appear here once BlueStacks "
+                   "and its instances are found.")
+    _PROMPT_TEXT = "Select an instance to see its telemetry-block status."
+    _NOTE = (
+        "This null-routes ad, tracker, and analytics domains in the instance's "
+        "guest hosts file — the same trick as a phone ad-blocker, but applied "
+        "offline while the instance is shut down. It affects only the emulator "
+        "(never your Windows machine) and is fully reversible.\n\n"
+        "The block covers a version's shared system image, so it applies to "
+        "every instance of that Android version. It does not touch Google Play, "
+        "GMS, or an app's own servers."
+    )
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+
+        layout.addWidget(QLabel("1. Choose an instance"))
+        self.instance_group = QButtonGroup(self)
+        self.instance_group.setExclusive(True)
+        self._instance_layout = QVBoxLayout()
+        layout.addLayout(self._instance_layout)
+        self.no_instances_label = QLabel(self._EMPTY_TEXT)
+        self.no_instances_label.setWordWrap(True)
+        self.no_instances_label.hide()
+        layout.addWidget(self.no_instances_label)
+
+        self.status_label = QLabel(self._PROMPT_TEXT)
+        self.status_label.setWordWrap(True)
+        self.status_label.setObjectName("PrivacyStatus")
+        layout.addWidget(self.status_label)
+
+        button_row = QHBoxLayout()
+        self.block_button = QPushButton("Block ads & telemetry")
+        self.block_button.setToolTip(
+            "Writes the block into the guest hosts file offline. Closes BlueStacks "
+            "first; reversible.")
+        self.block_button.clicked.connect(self.block_requested.emit)
+        self.unblock_button = QPushButton("Remove block")
+        self.unblock_button.setToolTip("Restores the guest hosts file offline.")
+        self.unblock_button.clicked.connect(self.unblock_requested.emit)
+        button_row.addWidget(self.block_button)
+        button_row.addWidget(self.unblock_button)
+        layout.addLayout(button_row)
+
+        note = QLabel(self._NOTE)
+        note.setWordWrap(True)
+        note.setObjectName("PrivacyNote")
+        layout.addWidget(note)
+        layout.addStretch(1)
+
+        self._radios: dict[str, QRadioButton] = {}
+        self._statuses: dict[str, dict | None] = {}
+        self._busy = False
+        self._update()
+
+    def set_busy(self, busy: bool) -> None:
+        self._busy = busy
+        self._update()
+
+    def _clear_radios(self) -> None:
+        for radio in self._radios.values():
+            self.instance_group.removeButton(radio)
+            radio.deleteLater()
+        self._radios = {}
+        while self._instance_layout.count():
+            item = self._instance_layout.takeAt(0)
+            if item and item.widget():
+                item.widget().deleteLater()
+
+    def set_instances(self, statuses: dict) -> None:
+        """``statuses`` maps unique_id -> telemetry_block.status() dict (or None
+        if not blocked). Preserves selection if still present."""
+        previous = self.selected_instance_id()
+        self._clear_radios()
+        self._statuses = dict(statuses)
+        for uid in sorted(statuses):
+            radio = QRadioButton(uid)
+            radio.toggled.connect(self._update)
+            self.instance_group.addButton(radio)
+            self._instance_layout.addWidget(radio)
+            self._radios[uid] = radio
+        if previous in self._radios:
+            self._radios[previous].setChecked(True)
+        self.no_instances_label.setVisible(not statuses)
+        self._update()
+
+    def selected_instance_id(self):
+        for uid, radio in self._radios.items():
+            if radio.isChecked():
+                return uid
+        return None
+
+    def _status_text(self, uid) -> str:
+        if uid is None:
+            return self._PROMPT_TEXT
+        st = self._statuses.get(uid)
+        if not st:
+            return "%s: no telemetry block applied." % uid
+        return "%s: blocking %s ad/telemetry domains." % (uid, st.get("domains", "?"))
+
+    def _update(self, *_args) -> None:
+        uid = self.selected_instance_id()
+        blocked = bool(uid and self._statuses.get(uid))
+        self.status_label.setText(self._status_text(uid))
+        # Block when an instance is chosen and it's not blocked; Remove once it is.
+        show_block = bool(uid) and not blocked
+        self.block_button.setVisible(show_block)
+        self.unblock_button.setVisible(blocked)
+        busy = self._busy
+        self.block_button.setEnabled(show_block and not busy)
+        self.unblock_button.setEnabled(blocked and not busy)


### PR DESCRIPTION
Adds a **Privacy** tab that null-routes ad/tracker/analytics domains in an instance's guest hosts file — a surgical, emulator-only, reversible telemetry block. Built clean-room (my own live capture + public ad-network sources, nothing from any third-party debloat repo).

## What it does
- `telemetry_block.py`: writes `0.0.0.0` entries for a conservative, independently-sourced list of ad/tracker/attribution domains (plus `rtbhouse` — the ad exchange caught in a live capture of the player) into the guest `/system/etc/hosts`, **offline** via the same Root.vhd + `debugfs` path the Magisk install uses. Backs up the original once, idempotent (marked block), e2fsck-verified; `remove()` restores it exactly.
- Emulator-only: it never touches the user's Windows hosts, and it doesn't block Google Play, GMS, or an app's own servers.
- New **Privacy** nav-rail tab: pick an instance → Block / Remove, with live status, run through the elevated worker (closes BlueStacks first).

## Not yet live-verified
168 tests cover the pure logic + state + page. The offline hosts write and the exact domain list still want a pass on a clean instance — the list is a starter, to be finalized from a live capture of the target build.